### PR TITLE
removed `bytes` type annotation

### DIFF
--- a/frontc/clexer.mll
+++ b/frontc/clexer.mll
@@ -396,7 +396,7 @@ and chr =
 {
 
 (*** get_buffer ***)
-let get_buffer (hr : handle ref) (dst : bytes) (len : int) : int =
+let get_buffer (hr : handle ref) dst (len : int) : int =
 	(*let (inter, chan, line, buffer, pos, lineno, out, name) = !hr in*)
 	let h = !hr in
 	try


### PR DESCRIPTION
Finally decided to remove type annotation in order to make `FrontC` less dependable from compiler version.