### PR TITLE
Support functions with pure-asm bodies

### DIFF
--- a/frontc/clexer.mll
+++ b/frontc/clexer.mll
@@ -164,7 +164,7 @@ let keywords =
 		("for", fun _ -> FOR (curfile(), curline()));
 		("if", fun _ -> IF (curfile(), curline()));
 		("else", fun _ -> ELSE (curfile(), curline()));
-		("asm", id ASM);
+		("asm", id ASM); ("__asm__", id ASM);
 	]
 
 (*** Specific GNU ***)

--- a/frontc/cparser.mly
+++ b/frontc/cparser.mly
@@ -290,6 +290,17 @@ global_type global_defs SEMICOLON
       | _ ->
 	 parse_error ()
     }
+  | 	global_type global_proto basic_asm SEMICOLON
+    {
+      let (_, base, _, _) = $2 in
+      match base with
+	PROTO _ ->
+	 FUNDEF (set_single $1 $2, ([], $3))
+      | OLD_PROTO _ ->
+	 OLDFUNDEF (set_single $1 $2, [], ([], $3))
+      | _ ->
+	 raise Parsing.Parse_error
+    }
   |		global_type old_proto old_pardefs body
     { OLDFUNDEF (set_single $1 $2, List.rev $3, (snd $4)) }
   |		global_type SEMICOLON
@@ -1057,6 +1068,14 @@ SEMICOLON opt_expression RPAREN statement
     { Clexer.test_gcc(); GNU_ASM ($3, List.rev $4, List.rev $5, List.rev $6) }
 ;
 
+/* "Basic asm" https://gcc.gnu.org/onlinedocs/gcc/Basic-Asm.html#Basic-Asm */
+basic_asm:
+ASM opt_gcc_attributes LPAREN string_list RPAREN
+  { ASM $4 }
+| ASM VOLATILE opt_gcc_attributes LPAREN string_list RPAREN
+  { ASM $5 }
+| ASM opt_gcc_attributes VOLATILE LPAREN string_list RPAREN
+  { ASM $5 }
 
 /*** GNU asm ***/
 gnu_asm_io:

--- a/frontc/cparser.mly
+++ b/frontc/cparser.mly
@@ -299,7 +299,7 @@ global_type global_defs SEMICOLON
       | OLD_PROTO _ ->
 	 OLDFUNDEF (set_single $1 $2, [], ([], $3))
       | _ ->
-	 raise Parsing.Parse_error
+	 parse_error ()
     }
   |		global_type old_proto old_pardefs body
     { OLDFUNDEF (set_single $1 $2, List.rev $3, (snd $4)) }


### PR DESCRIPTION
Fixes #10.

Adds support for functions which use [basic asm](https://gcc.gnu.org/onlinedocs/gcc/Basic-Asm.html#Basic-Asm) to define a function without having a traditional body (i.e., no `{` and `}`). In the process, also informs the lexer that `__asm__` is a synonym for `asm` (as explained at the same link).