### PR TITLE
[c11] Enables type redefinitions

### DIFF
--- a/ctoxml/dune
+++ b/ctoxml/dune
@@ -3,3 +3,10 @@
   (public_name ctoxml)
   (package ctoxml)
   (libraries FrontC))
+
+(env
+ (_ (binaries (./ctoxml_bin.exe as ctoxml))))
+
+
+(cram
+  (deps ${bin:ctoxml}))

--- a/dune
+++ b/dune
@@ -1,3 +1,2 @@
 (cram
- (deps printc/printc_bin.exe
-       ctoxml/ctoxml_bin.exe))
+ (deps printc/printc_bin.exe))

--- a/dune
+++ b/dune
@@ -1,2 +1,3 @@
 (cram
- (deps printc/printc_bin.exe))
+ (deps printc/printc_bin.exe
+       ctoxml/ctoxml_bin.exe))

--- a/frontc/clexer.mll
+++ b/frontc/clexer.mll
@@ -180,6 +180,21 @@ let init_lexicon _ =
   List.iter add keywords;
   if has_gcc ()  then List.iter add gnu_keywords
 
+let typename name =
+  match StringHashtbl.find_opt lexicon name with
+  | None -> name
+  | Some token -> match token () with
+    | NAMED_TYPE name -> name
+    | _ -> name
+
+let typenames name = List.length (StringHashtbl.find_all lexicon name)
+let phantomized_name =
+  let phantoms = ref 0 in
+    fun name ->
+      incr phantoms;
+      Format.asprintf "%s$%d" name !phantoms
+
+
 let add_type name =
   StringHashtbl.add lexicon name (id (NAMED_TYPE name))
 

--- a/frontc/clexer.mll
+++ b/frontc/clexer.mll
@@ -187,14 +187,6 @@ let typename name =
     | NAMED_TYPE name -> name
     | _ -> name
 
-let typenames name = List.length (StringHashtbl.find_all lexicon name)
-let phantomized_name =
-  let phantoms = ref 0 in
-    fun name ->
-      incr phantoms;
-      Format.asprintf "%s$%d" name !phantoms
-
-
 let add_type name =
   StringHashtbl.add lexicon name (id (NAMED_TYPE name))
 

--- a/frontc/cparser.mly
+++ b/frontc/cparser.mly
@@ -498,10 +498,8 @@ typedef_dec opt_gcc_attributes
     {(fst $1, snd $1, $2, NOTHING)}
 ;
 typedef_dec:
-  | IDENT
+  | IDENT | NAMED_TYPE
     {($1, NO_TYPE)}
-  | NAMED_TYPE
-    {(Clexer.phantomized_name $1, NO_TYPE)}
   |		STAR typedef_dec
     {(fst $2, set_type (PTR NO_TYPE) (snd $2))}
   |		STAR RESTRICT typedef_dec

--- a/frontc/cparser.mly
+++ b/frontc/cparser.mly
@@ -498,8 +498,10 @@ typedef_dec opt_gcc_attributes
     {(fst $1, snd $1, $2, NOTHING)}
 ;
 typedef_dec:
-IDENT
+  | IDENT
     {($1, NO_TYPE)}
+  | NAMED_TYPE
+    {(Clexer.phantomized_name $1, NO_TYPE)}
   |		STAR typedef_dec
     {(fst $2, set_type (PTR NO_TYPE) (snd $2))}
   |		STAR RESTRICT typedef_dec

--- a/frontc/ctoxml.ml
+++ b/frontc/ctoxml.ml
@@ -6,361 +6,361 @@
  *)
 
 (** Transform a C abstract syntax into XML document.
- *)
+*)
 
 open Cabs
 
 
 let rec convert_storage store def =
-	match store with
-	  NO_STORAGE -> convert_storage def AUTO
-	| AUTO -> "auto"
-	| STATIC -> "static"
-	| EXTERN ->"extern"
-	| REGISTER -> "register"
+  match store with
+    NO_STORAGE -> convert_storage def AUTO
+  | AUTO -> "auto"
+  | STATIC -> "static"
+  | EXTERN ->"extern"
+  | REGISTER -> "register"
 
 
 let convert_un op =
-	match op with
-	  MINUS -> "neg"
-	| PLUS -> "pos"
-	| NOT -> "not"
-	| BNOT -> "bnot"
-	| MEMOF -> "memof"
-	| ADDROF -> "addrof"
-	| PREINCR -> "preinc"
-	| PREDECR -> "predecr"
-	| POSINCR -> "postinc"
-	| POSDECR -> "postdec"
+  match op with
+    MINUS -> "neg"
+  | PLUS -> "pos"
+  | NOT -> "not"
+  | BNOT -> "bnot"
+  | MEMOF -> "memof"
+  | ADDROF -> "addrof"
+  | PREINCR -> "preinc"
+  | PREDECR -> "predecr"
+  | POSINCR -> "postinc"
+  | POSDECR -> "postdec"
 
 
 let convert_bin op =
-	match op with
-	  ADD -> "add"
-	| SUB -> "sub"
-	| MUL -> "mul"
-	| DIV -> "div"
-	| MOD -> "mod"
-	| AND -> "and"
-	| OR -> "or"
-	| BAND -> "band"
-	| BOR -> "bor"
-	| XOR -> "xor"
-	| SHL -> "shl"
-	| SHR -> "shr"
-	| EQ -> "eq"
-	| NE -> "ne"
-	| LT -> "lt"
-	| GT -> "gt"
-	| LE -> "le"
-	| GE -> "ge"
-	| ASSIGN -> "set"
-	| ADD_ASSIGN -> "set_add"
-	| SUB_ASSIGN -> "set_sub"
-	| MUL_ASSIGN -> "set_mul"
-	| DIV_ASSIGN -> "set_div"
-	| MOD_ASSIGN -> "set_mod"
-	| BAND_ASSIGN -> "set_band"
-	| BOR_ASSIGN -> "set_bor"
-	| XOR_ASSIGN -> "set_xor"
-	| SHL_ASSIGN -> "set_shl"
-	| SHR_ASSIGN -> "set_shr"
+  match op with
+    ADD -> "add"
+  | SUB -> "sub"
+  | MUL -> "mul"
+  | DIV -> "div"
+  | MOD -> "mod"
+  | AND -> "and"
+  | OR -> "or"
+  | BAND -> "band"
+  | BOR -> "bor"
+  | XOR -> "xor"
+  | SHL -> "shl"
+  | SHR -> "shr"
+  | EQ -> "eq"
+  | NE -> "ne"
+  | LT -> "lt"
+  | GT -> "gt"
+  | LE -> "le"
+  | GE -> "ge"
+  | ASSIGN -> "set"
+  | ADD_ASSIGN -> "set_add"
+  | SUB_ASSIGN -> "set_sub"
+  | MUL_ASSIGN -> "set_mul"
+  | DIV_ASSIGN -> "set_div"
+  | MOD_ASSIGN -> "set_mod"
+  | BAND_ASSIGN -> "set_band"
+  | BOR_ASSIGN -> "set_bor"
+  | XOR_ASSIGN -> "set_xor"
+  | SHL_ASSIGN -> "set_shl"
+  | SHR_ASSIGN -> "set_shr"
 
 
 let rec convert_const c =
-	match c with
-	  CONST_INT v ->
-	  	Cxml.new_elt "int" [] [Cxml.new_text v]
-	| CONST_FLOAT v ->
-	  	Cxml.new_elt "float" [] [Cxml.new_text v]
-	| CONST_CHAR v ->
-	  	Cxml.new_elt "char" [] [Cxml.new_text v]
-	| CONST_STRING v ->
-	  	Cxml.new_elt "string" [] [Cxml.new_text v]
-	| CONST_COMPOUND exps ->
-		Cxml.new_elt "compound" [] (List.map convert_exp exps)
+  match c with
+    CONST_INT v ->
+    Cxml.new_elt "int" [] [Cxml.new_text v]
+  | CONST_FLOAT v ->
+    Cxml.new_elt "float" [] [Cxml.new_text v]
+  | CONST_CHAR v ->
+    Cxml.new_elt "char" [] [Cxml.new_text v]
+  | CONST_STRING v ->
+    Cxml.new_elt "string" [] [Cxml.new_text v]
+  | CONST_COMPOUND exps ->
+    Cxml.new_elt "compound" [] (List.map convert_exp exps)
 
 
 and convert_exp exp =
-	match exp with
-	  NOTHING ->
-	  	Cxml.new_elt "nothing" [] []
-	| UNARY (op, e) ->
-		Cxml.new_elt (convert_un op) [] [convert_exp e]
-	| BINARY (op, e1, e2) ->
-		Cxml.new_elt (convert_bin op) [] [convert_exp e1; convert_exp e2]
-	| QUESTION (c, t, e) ->
-		Cxml.new_elt "quest" []
-			[convert_exp c; convert_exp t; convert_exp e]
-	| CAST (t, e) ->
-		Cxml.new_elt "cast" [] [convert_type t; convert_exp e]
-	| CALL (f, args) ->
-		Cxml.new_elt "call" []
-			((convert_exp f) :: (List.map convert_exp args))
-	| COMMA exps ->
-		Cxml.new_elt "comma" [] (List.map convert_exp exps)
-	| CONSTANT c ->
-		convert_const c
-	| VARIABLE n ->
-		Cxml.new_elt "get" [("ref", n)] []
-	| EXPR_SIZEOF e ->
-		Cxml.new_elt "sizeof" [] [convert_exp e]
-	| TYPE_SIZEOF t ->
-		Cxml.new_elt "sizeof" [] [convert_type t]
-	| INDEX (b, i) ->
-		Cxml.new_elt "index" [] [convert_exp b; convert_exp i]
-	| MEMBEROF (b, n) ->
-		Cxml.new_elt "memberof" [("field", n)] [convert_exp b]
-	| MEMBEROFPTR (b, n) ->
-		Cxml.new_elt "memberofptr" [("field", n)] [convert_exp b]
-	| GNU_BODY (d, s) ->
-		Cxml.new_elt "body" [] (convert_block (d, s))
-	| EXPR_LINE (expr, file, line) ->
-		Cxml.new_elt "expr_line"
-			[("file", file); ("line", string_of_int line)]
-			[convert_exp expr]
+  match exp with
+    NOTHING ->
+    Cxml.new_elt "nothing" [] []
+  | UNARY (op, e) ->
+    Cxml.new_elt (convert_un op) [] [convert_exp e]
+  | BINARY (op, e1, e2) ->
+    Cxml.new_elt (convert_bin op) [] [convert_exp e1; convert_exp e2]
+  | QUESTION (c, t, e) ->
+    Cxml.new_elt "quest" []
+      [convert_exp c; convert_exp t; convert_exp e]
+  | CAST (t, e) ->
+    Cxml.new_elt "cast" [] [convert_type t; convert_exp e]
+  | CALL (f, args) ->
+    Cxml.new_elt "call" []
+      ((convert_exp f) :: (List.map convert_exp args))
+  | COMMA exps ->
+    Cxml.new_elt "comma" [] (List.map convert_exp exps)
+  | CONSTANT c ->
+    convert_const c
+  | VARIABLE n ->
+    Cxml.new_elt "get" [("ref", n)] []
+  | EXPR_SIZEOF e ->
+    Cxml.new_elt "sizeof" [] [convert_exp e]
+  | TYPE_SIZEOF t ->
+    Cxml.new_elt "sizeof" [] [convert_type t]
+  | INDEX (b, i) ->
+    Cxml.new_elt "index" [] [convert_exp b; convert_exp i]
+  | MEMBEROF (b, n) ->
+    Cxml.new_elt "memberof" [("field", n)] [convert_exp b]
+  | MEMBEROFPTR (b, n) ->
+    Cxml.new_elt "memberofptr" [("field", n)] [convert_exp b]
+  | GNU_BODY (d, s) ->
+    Cxml.new_elt "body" [] (convert_block (d, s))
+  | EXPR_LINE (expr, file, line) ->
+    Cxml.new_elt "expr_line"
+      [("file", file); ("line", string_of_int line)]
+      [convert_exp expr]
 
 
 and convert_stat stat =
-	match stat with
-	  NOP
-	  	-> Cxml.new_elt "nop" [] []
-	| COMPUTATION e
-		-> convert_exp e
-	| BLOCK (defs, stat)
-		-> Cxml.new_elt "block" [] (convert_block (defs, stat))
-	| SEQUENCE _
-		-> Cxml.new_elt "block" [] (convert_block ([], stat))
-	| IF (c, t, e)
-		-> Cxml.new_elt "if" []
-			[convert_exp c; convert_stat t; convert_stat e]
-	| WHILE (c, b)
-		-> Cxml.new_elt "while" [] [convert_exp c; convert_stat b]
-	| DOWHILE (c, b)
-		-> Cxml.new_elt "dowhile" [] [convert_exp c; convert_stat b]
-	| FOR (i, c, n, b)
-		-> Cxml.new_elt "for" []
-			[convert_exp i; convert_exp c; convert_exp n; convert_stat b]
-	| BREAK
-		-> Cxml.new_elt "break" [] []
-	| CONTINUE
-		-> Cxml.new_elt "continue" [] []
-	| RETURN e
-		-> Cxml.new_elt "return" [] [convert_exp e]
-	| SWITCH (e, s)
-		-> Cxml.new_elt "switch" [] [convert_exp e; convert_stat s]
-	| CASE (e, s)
-		-> Cxml.new_elt "case" [] [convert_exp e; convert_stat s]
-	| DEFAULT s
-		-> Cxml.new_elt "default" [] [convert_stat s]
-	| LABEL (l, s)
-		-> Cxml.new_elt "label" [("id", l)] [convert_stat s]
-	| GOTO l
-		-> Cxml.new_elt "goto" [("ref", l)] []
-	| ASM text
-		-> Cxml.new_elt "asm" [] [Cxml.new_text text]
-	| GNU_ASM (text, outs, ins, clobbers)
-		-> Cxml.new_elt "gnu_asm" []
-			((Cxml.new_elt "text" [] [Cxml.new_text text])
-			::(convert_gnu_asm outs ins clobbers))
-	| STAT_LINE (stat, file, line)
-		-> Cxml.new_elt "stat_line"
-			[("file", file); ("line", (string_of_int line))]
-			[convert_stat stat]
+  match stat with
+    NOP
+    -> Cxml.new_elt "nop" [] []
+  | COMPUTATION e
+    -> convert_exp e
+  | BLOCK (defs, stat)
+    -> Cxml.new_elt "block" [] (convert_block (defs, stat))
+  | SEQUENCE _
+    -> Cxml.new_elt "block" [] (convert_block ([], stat))
+  | IF (c, t, e)
+    -> Cxml.new_elt "if" []
+	 [convert_exp c; convert_stat t; convert_stat e]
+  | WHILE (c, b)
+    -> Cxml.new_elt "while" [] [convert_exp c; convert_stat b]
+  | DOWHILE (c, b)
+    -> Cxml.new_elt "dowhile" [] [convert_exp c; convert_stat b]
+  | FOR (i, c, n, b)
+    -> Cxml.new_elt "for" []
+	 [convert_exp i; convert_exp c; convert_exp n; convert_stat b]
+  | BREAK
+    -> Cxml.new_elt "break" [] []
+  | CONTINUE
+    -> Cxml.new_elt "continue" [] []
+  | RETURN e
+    -> Cxml.new_elt "return" [] [convert_exp e]
+  | SWITCH (e, s)
+    -> Cxml.new_elt "switch" [] [convert_exp e; convert_stat s]
+  | CASE (e, s)
+    -> Cxml.new_elt "case" [] [convert_exp e; convert_stat s]
+  | DEFAULT s
+    -> Cxml.new_elt "default" [] [convert_stat s]
+  | LABEL (l, s)
+    -> Cxml.new_elt "label" [("id", l)] [convert_stat s]
+  | GOTO l
+    -> Cxml.new_elt "goto" [("ref", l)] []
+  | ASM text
+    -> Cxml.new_elt "asm" [] [Cxml.new_text text]
+  | GNU_ASM (text, outs, ins, clobbers)
+    -> Cxml.new_elt "gnu_asm" []
+	 ((Cxml.new_elt "text" [] [Cxml.new_text text])
+	  ::(convert_gnu_asm outs ins clobbers))
+  | STAT_LINE (stat, file, line)
+    -> Cxml.new_elt "stat_line"
+	 [("file", file); ("line", (string_of_int line))]
+	 [convert_stat stat]
 
 and convert_gnu_asm outs ins clobbers =
-	let process tag id reg exp =
-		let attrs = if id = "" then [] else [("id", id)] in
-		let attrs = ("reg", reg)::attrs in
-		Cxml.new_elt tag attrs [convert_exp exp] in
-	List.append
-		(List.map (fun (id, reg, exp) -> process "out" id reg exp) outs)
-		(List.append
-			(List.map (fun (id, reg, exp) -> process "in" id reg exp) ins)
-			(List.map (fun reg -> (Cxml.new_elt "clobber" [("reg", reg)] [])) clobbers)
-		)
+  let process tag id reg exp =
+    let attrs = if id = "" then [] else [("id", id)] in
+    let attrs = ("reg", reg)::attrs in
+    Cxml.new_elt tag attrs [convert_exp exp] in
+  List.append
+    (List.map (fun (id, reg, exp) -> process "out" id reg exp) outs)
+    (List.append
+       (List.map (fun (id, reg, exp) -> process "in" id reg exp) ins)
+       (List.map (fun reg -> (Cxml.new_elt "clobber" [("reg", reg)] [])) clobbers)
+    )
 
 and convert_seq stat =
-	match stat with
-	  SEQUENCE (s1, s2) -> List.append (convert_seq s1) (convert_seq s2)
-	| _ -> [convert_stat stat]
+  match stat with
+    SEQUENCE (s1, s2) -> List.append (convert_seq s1) (convert_seq s2)
+  | _ -> [convert_stat stat]
 
 
 and convert_block (defs, stat) =
-	let defs = List.flatten (List.map convert_def defs) in
-	let seq = convert_seq stat in
-	List.append defs seq
+  let defs = List.flatten (List.map convert_def defs) in
+  let seq = convert_seq stat in
+  List.append defs seq
 
 
 and convert_fields fields =
-	let convert_names (_, _, names) =
-		let convert_name (name, _type, _, _) =
-			Cxml.new_elt "field" [("name", name)] [convert_type _type] in
-		List.map convert_name names in
-	List.flatten (List.map convert_names fields)
+  let convert_names (_, _, names) =
+    let convert_name (name, _type, _, _) =
+      Cxml.new_elt "field" [("name", name)] [convert_type _type] in
+    List.map convert_name names in
+  List.flatten (List.map convert_names fields)
 
 
 and convert_values values =
-	let convert_value (name, exp) =
-		Cxml.new_elt "value" [("name", name)] [convert_exp exp] in
-	List.map convert_value values
+  let convert_value (name, exp) =
+    Cxml.new_elt "value" [("name", name)] [convert_exp exp] in
+  List.map convert_value values
 
 
 and convert_proto _type =
 
-	let (rtype, args, vararg) =
-		match _type with
-		  PROTO (_type, args, vararg) -> (_type, args, vararg)
-		| _ -> raise UnconsistentDef in
-	let relt = Cxml.new_elt "type" [] [convert_type rtype] in
+  let (rtype, args, vararg) =
+    match _type with
+      PROTO (_type, args, vararg) -> (_type, args, vararg)
+    | _ -> raise UnconsistentDef in
+  let relt = Cxml.new_elt "type" [] [convert_type rtype] in
 
-	let convert_arg (_, store, (name, _type, _, _)) args =
-		if _type = VOID then args else
-		let elt = Cxml.new_elt "param"
-			[("name", name); ("store", convert_storage store AUTO)]
-			[convert_type _type] in
-		elt :: args in
-	let aelts = List.fold_right convert_arg args [] in
+  let convert_arg (_, store, (name, _type, _, _)) args =
+    if _type = VOID then args else
+      let elt = Cxml.new_elt "param"
+	  [("name", name); ("store", convert_storage store AUTO)]
+	  [convert_type _type] in
+      elt :: args in
+  let aelts = List.fold_right convert_arg args [] in
 
-	let elts =
-		if not vararg then aelts
-		else List.append aelts [Cxml.new_elt "vararg" [] []] in
+  let elts =
+    if not vararg then aelts
+    else List.append aelts [Cxml.new_elt "vararg" [] []] in
 
-	relt :: elts
+  relt :: elts
 
 
 and convert_type _type =
-	let base_type name = Cxml.new_elt name [] [] in
-	match _type with
-	  NO_TYPE -> convert_type (INT (NO_SIZE, NO_SIGN))
-	| VOID -> base_type "void"
-	| CHAR NO_SIGN
-	| CHAR SIGNED -> base_type "char"
-	| CHAR UNSIGNED -> base_type "uchar"
-	| INT (SHORT, NO_SIGN)
-	| INT (SHORT, SIGNED) -> base_type "short"
-	| INT (SHORT, UNSIGNED) -> base_type "ushort"
-	| INT (NO_SIZE, NO_SIGN)
-	| INT (LONG, NO_SIGN)
-	| INT (NO_SIZE, SIGNED)
-	| INT (LONG, SIGNED) -> base_type "long"
-	| INT (NO_SIZE, UNSIGNED)
-	| INT (LONG, UNSIGNED) -> base_type "ulong"
-	| INT (LONG_LONG, NO_SIGN)
-	| INT (LONG_LONG, SIGNED) -> base_type "llong"
-	| INT (LONG_LONG, UNSIGNED) -> base_type "ulong"
-	| BITFIELD (NO_SIGN, exp) -> Cxml.new_elt "bits" [] [convert_exp exp]
-	| BITFIELD (SIGNED, exp) -> Cxml.new_elt "bits" [] [convert_exp exp]
-	| BITFIELD (UNSIGNED, exp) -> Cxml.new_elt "ubits" [] [convert_exp exp]
-	| FLOAT false -> base_type "float"
-	| FLOAT true
-	| DOUBLE false -> base_type "double"
-	| DOUBLE true -> base_type "ldouble"
+  let base_type name = Cxml.new_elt name [] [] in
+  match _type with
+    NO_TYPE -> convert_type (INT (NO_SIZE, NO_SIGN))
+  | VOID -> base_type "void"
+  | CHAR NO_SIGN
+  | CHAR SIGNED -> base_type "char"
+  | CHAR UNSIGNED -> base_type "uchar"
+  | INT (SHORT, NO_SIGN)
+  | INT (SHORT, SIGNED) -> base_type "short"
+  | INT (SHORT, UNSIGNED) -> base_type "ushort"
+  | INT (NO_SIZE, NO_SIGN)
+  | INT (LONG, NO_SIGN)
+  | INT (NO_SIZE, SIGNED)
+  | INT (LONG, SIGNED) -> base_type "long"
+  | INT (NO_SIZE, UNSIGNED)
+  | INT (LONG, UNSIGNED) -> base_type "ulong"
+  | INT (LONG_LONG, NO_SIGN)
+  | INT (LONG_LONG, SIGNED) -> base_type "llong"
+  | INT (LONG_LONG, UNSIGNED) -> base_type "ulong"
+  | BITFIELD (NO_SIGN, exp) -> Cxml.new_elt "bits" [] [convert_exp exp]
+  | BITFIELD (SIGNED, exp) -> Cxml.new_elt "bits" [] [convert_exp exp]
+  | BITFIELD (UNSIGNED, exp) -> Cxml.new_elt "ubits" [] [convert_exp exp]
+  | FLOAT false -> base_type "float"
+  | FLOAT true
+  | DOUBLE false -> base_type "double"
+  | DOUBLE true -> base_type "ldouble"
 
-	| PTR _type -> Cxml.new_elt "ptr" [] [convert_type _type]
-	| CONST _type -> Cxml.new_elt "const" [] [convert_type _type]
-	| VOLATILE _type -> Cxml.new_elt "volatile" [] [convert_type _type]
-	| NAMED_TYPE name -> Cxml.new_elt "type" [("ref", name)] []
-	| RESTRICT_PTR _type -> Cxml.new_elt "restrict" [] [convert_type _type]
+  | PTR _type -> Cxml.new_elt "ptr" [] [convert_type _type]
+  | CONST _type -> Cxml.new_elt "const" [] [convert_type _type]
+  | VOLATILE _type -> Cxml.new_elt "volatile" [] [convert_type _type]
+  | NAMED_TYPE name -> Cxml.new_elt "type" [("ref", name)] []
+  | RESTRICT_PTR _type -> Cxml.new_elt "restrict" [] [convert_type _type]
 
-	| ARRAY  (_type, size) ->
-		Cxml.new_elt "array" [] [
-			convert_type _type;
-			Cxml.new_elt "size" [] [convert_exp size]
-		]
+  | ARRAY  (_type, size) ->
+    Cxml.new_elt "array" [] [
+      convert_type _type;
+      Cxml.new_elt "size" [] [convert_exp size]
+    ]
 
-	| STRUCT (name, fields) ->
-		let id = if fields = [] then "ref" else "id" in
-		Cxml.new_elt "struct"
-			(if name <> "" then [(id, "struct:" ^ name)] else [])
-			(convert_fields fields)
+  | STRUCT (name, fields) ->
+    let id = if fields = [] then "ref" else "id" in
+    Cxml.new_elt "struct"
+      (if name <> "" then [(id, "struct:" ^ name)] else [])
+      (convert_fields fields)
 
-	| UNION (name, fields) ->
-		let id = if fields = [] then "ref" else "id" in
-		Cxml.new_elt "union"
-			(if name <> "" then [(id, "union:" ^ name)] else [])
-			(convert_fields fields)
+  | UNION (name, fields) ->
+    let id = if fields = [] then "ref" else "id" in
+    Cxml.new_elt "union"
+      (if name <> "" then [(id, "union:" ^ name)] else [])
+      (convert_fields fields)
 
-	| ENUM (name, values) ->
-		let id = if values = [] then "ref" else "id" in
-		Cxml.new_elt "enum"
-			(if name <> "" then [(id, "enum:" ^ name)] else [])
-			(convert_values values)
+  | ENUM (name, values) ->
+    let id = if values = [] then "ref" else "id" in
+    Cxml.new_elt "enum"
+      (if name <> "" then [(id, "enum:" ^ name)] else [])
+      (convert_values values)
 
-	| PROTO (_, _, _) ->
-		Cxml.new_elt "fun" [] (convert_proto _type)
+  | PROTO (_, _, _) ->
+    Cxml.new_elt "fun" [] (convert_proto _type)
 
-	| OLD_PROTO (_, _, _) ->
-		Cxml.new_elt "fun" [] [Cxml.new_elt "vararg" [] []]
+  | OLD_PROTO (_, _, _) ->
+    Cxml.new_elt "fun" [] [Cxml.new_elt "vararg" [] []]
 
-	| GNU_TYPE (attrs, _type) ->
-		Cxml.add_children (convert_type _type) (List.map convert_gnu_attr attrs)
+  | GNU_TYPE (attrs, _type) ->
+    Cxml.add_children (convert_type _type) (List.map convert_gnu_attr attrs)
 
-	| TYPE_LINE (file, line, _) ->
-		Cxml.new_elt "type_line"
-			[ ("file", file); ("line", string_of_int line) ]
-			[convert_type _type]
+  | TYPE_LINE (file, line, _) ->
+    Cxml.new_elt "type_line"
+      [ ("file", file); ("line", string_of_int line) ]
+      [convert_type _type]
 
 and convert_gnu_attr attr =
-	match attr with
-	  GNU_NONE
-	  	-> Cxml.new_elt "none" [] []
-	| GNU_ID id
-		-> Cxml.new_elt "id" [("value", id)] []
-	| GNU_CST cst
-		-> convert_const cst
-	| GNU_EXTENSION
-		-> Cxml.new_elt "extension" [] []
-	| GNU_INLINE
-		-> Cxml.new_elt "inline" [] []
-	| GNU_CALL (id, attrs)
-		-> Cxml.new_elt "call" [("id", id)] (List.map convert_gnu_attr attrs)
+  match attr with
+    GNU_NONE
+    -> Cxml.new_elt "none" [] []
+  | GNU_ID id
+    -> Cxml.new_elt "id" [("value", id)] []
+  | GNU_CST cst
+    -> convert_const cst
+  | GNU_EXTENSION
+    -> Cxml.new_elt "extension" [] []
+  | GNU_INLINE
+    -> Cxml.new_elt "inline" [] []
+  | GNU_CALL (id, attrs)
+    -> Cxml.new_elt "call" [("id", id)] (List.map convert_gnu_attr attrs)
 
 and convert_fundef _type store name vars body =
 
-	let proto_elts = convert_proto _type in
-	let body_elt = Cxml.new_elt "body" [] (convert_block (vars, body)) in
+  let proto_elts = convert_proto _type in
+  let body_elt = Cxml.new_elt "body" [] (convert_block (vars, body)) in
 
-	Cxml.new_elt "fundef"
-		[
-			("id", name);
-			("store", convert_storage store AUTO)
-		]
-		(List.append proto_elts [body_elt])
+  Cxml.new_elt "fundef"
+    [
+      ("id", name);
+      ("store", convert_storage store AUTO)
+    ]
+    (List.append proto_elts [body_elt])
 
 
 and convert_name store (name, _type, _, exp) =
-	let attrs = [("id", name); ("store", (convert_storage store AUTO))] in
-	match _type with
-	  PROTO _ ->
-	  	Cxml.new_elt "fundec" attrs (convert_proto _type)
-	| _ ->
-		let type_elt = convert_type _type in
-		let elts =
-			if exp = NOTHING then [type_elt]
-			else type_elt :: [convert_exp exp] in
-		Cxml.new_elt "var" attrs elts
+  let attrs = [("id", name); ("store", (convert_storage store AUTO))] in
+  match _type with
+    PROTO _ ->
+    Cxml.new_elt "fundec" attrs (convert_proto _type)
+  | _ ->
+    let type_elt = convert_type _type in
+    let elts =
+      if exp = NOTHING then [type_elt]
+      else type_elt :: [convert_exp exp] in
+    Cxml.new_elt "var" attrs elts
 
 
 and convert_typedef store (name, _type, _, _) =
-	Cxml.new_elt "type"
-		[("id", name); ("store", (convert_storage store AUTO))]
-		[convert_type _type]
+  Cxml.new_elt "type"
+    [("id", name); ("store", (convert_storage store AUTO))]
+    [convert_type _type]
 
 
 and convert_onlytypedef _type =
-	convert_type _type
+  convert_type _type
 
 
 and convert_def def =
-	match def with
-	  FUNDEF ((_, store, (name, _type, _, _)), (vars, body)) ->
-	  	[convert_fundef _type store name vars body]
-	| OLDFUNDEF (_, _, _) ->
-		raise UnconsistentDef
-	| DECDEF (_, store, names) ->
-		List.map (convert_name store) names
-	| TYPEDEF ((_, store, names), _) ->
-		List.map (fun name -> convert_typedef store name) names
-	| ONLYTYPEDEF (_type, _, _) ->
-		[convert_onlytypedef _type]
+  match def with
+    FUNDEF ((_, store, (name, _type, _, _)), (vars, body)) ->
+    [convert_fundef _type store name vars body]
+  | OLDFUNDEF (_, _, _) ->
+    raise UnconsistentDef
+  | DECDEF (_, store, names) ->
+    List.map (convert_name store) names
+  | TYPEDEF ((_, store, names), _) ->
+    List.map (fun name -> convert_typedef store name) names
+  | ONLYTYPEDEF (_type, _, _) ->
+    [convert_onlytypedef _type]

--- a/frontc/cxml.ml
+++ b/frontc/cxml.ml
@@ -1,222 +1,278 @@
-(* 
- *	$Id$
- *	Copyright (c) 2003, Hugues Cassé <hugues.casse@laposte.net>
+(*
+ * $Id$
+ * Copyright (c) 2003, Hugues Cassé <hugues.casse@laposte.net>
  *
- *	Pretty printer of XML document.
+ * Pretty printer of XML document.
  *)
 
 
 (** Provide types and pretty printing for XML.
- *)
+*)
 
 
 (** Attribute representation.
- *)
+*)
 type attr = string * string
 
 
 (** Representation of nodes.
- *)
+*)
 type node =
-	|	TEXT of string							(** Simple text *)
-	| 	COM of string							(** Commentary *)
-	|	PI of string * string					(** Processing instruction *)
-	|	ELT of string * attr list * node list	(** Element *)
+  | TEXT of string       (** Simple text *)
+  | COM of string       (** Commentary *)
+  | PI of string * string     (** Processing instruction *)
+  | ELT of string * attr list * node list (** Element *)
 
 
 (** Representation of an XML document.
- *)
+*)
 type document = {
-	version: string;	(** Version, usually 1.0 *)
-	encoding: string;	(** Encoding (only current encoding supported now) *)
-	standalone: bool;	(** Standalone attribute *)
-	element: node;		(** Document root element *)
+  version: string; (** Version, usually 1.0 *)
+  encoding: string; (** Encoding (only current encoding supported now) *)
+  standalone: bool; (** Standalone attribute *)
+  element: node;  (** Document root element *)
 }
 
 
+
+(** [validate_identifiers elt] validates that identifiers in the
+    document are unique and non-empty.
+
+    @since 4.1.0  *)
+let validate_identifiers toplevel =
+  let open Set.Make(String) in
+  let rec node ids x ~accept ~reject = match x with
+  | TEXT _ | COM _ | PI _ -> accept ids
+  | ELT (_,attrs,xs) as elt ->
+    match List.assoc_opt "id" attrs with
+    | None -> nodes ids xs ~accept ~reject
+    | Some "" -> reject elt
+    | Some id -> if mem id ids
+      then reject elt
+      else nodes (add id ids) xs ~reject ~accept
+  and nodes ids xs ~accept ~reject = match xs with
+    | [] -> accept ids
+    | x :: xs -> node ids x ~reject ~accept:(fun ids ->
+      nodes ids xs ~accept ~reject) in
+  node empty toplevel
+    ~accept:(fun _ -> Ok toplevel)
+    ~reject:(fun elt -> Error elt)
+
+(** [deduplicate elt] traverses [elt] and removes all
+    sub-elements with duplicating identifiers.
+
+    When several elements have the same identifier the first (in the
+    DSF traversal order) element is preserved and all subsequent are
+    removed.
+
+    If all children of a parent are duplicates of some other elements,
+    then the father is still preserved with an empty list of children
+    (unless it is itself a duplicate of some other element).
+
+    @since 4.1.0  *)
+let deduplicate top =
+  let module Ids = Set.Make(String) in
+  let check_id ids attrs = match List.assoc_opt "id" attrs with
+    | None -> Ok ids
+    | Some id ->
+      if Ids.mem id ids then Error ()
+      else Ok (Ids.add id ids) in
+  let rec node ids elt ~accept ~reject = match elt with
+    | TEXT _ | COM _ | PI _ as elt -> accept ids elt
+    | ELT (name,attrs,xs) -> match check_id ids attrs with
+      | Error () -> reject ()
+      | Ok ids -> nodes ids xs @@ fun ids xs ->
+        accept ids (ELT (name,attrs,xs))
+  and nodes ids xs accept = match xs with
+    | [] -> accept ids []
+    | x :: xs ->
+      node ids x
+        ~reject:(fun () -> nodes ids xs accept)
+        ~accept:(fun ids x -> nodes ids xs @@ fun ids xs ->
+                  accept ids (x::xs)) in
+  node Ids.empty top ~accept:(fun _ x -> x) ~reject:(fun () -> top)
+
+
+
 (** Build a simple document with default initialization.
-	@param elt	Main element of the document.
+    @param elt Main element of the document.
 *)
 let new_simple_doc elt: document =
-	{
-		version = "1.0";
-		encoding = "iso-8859-1";
-		standalone = true;
-		element = elt
-	}
+  {
+    version = "1.0";
+    encoding = "iso-8859-1";
+    standalone = true;
+    element = deduplicate elt
+  }
 
 
 (** Build a full document.
-	@param vers	XML version.
-	@param enc	Document encoding.
-	@param sa	Stand-alone attribute.
-	@param elt	Document element.
- *)
+    @param vers XML version.
+    @param enc Document encoding.
+    @param sa Stand-alone attribute.
+    @param elt Document element.
+*)
 let new_doc vers enc sa elt: document =
-	{
-		version = vers;
-		encoding = enc;
-		standalone = sa;
-		element = elt
-	}
+  {
+    version = vers;
+    encoding = enc;
+    standalone = sa;
+    element = deduplicate elt
+  }
 
 
 (** Build an attribute.
-	@param name	Name of the attribute.
-	@param cont	Content of the attribute.
- *)
+    @param name Name of the attribute.
+    @param cont Content of the attribute.
+*)
 let new_attr name cont: attr = (name, cont)
 
 
 (** Build a new element.
-	@param name		Name of the element.
-	@param attrs	Attributes.
-	@param children	Children nodes.
- *)
+    @param name  Name of the element.
+    @param attrs Attributes.
+    @param children Children nodes.
+*)
 let new_elt name attrs children = ELT(name, attrs, children)
 
 
 (** Build a new text node.
-	@param text	Content of the node.
- *)
+    @param text Content of the node.
+*)
 let new_text text = TEXT text
 
 
 (** Add children to an element node.
-	@param node		Element to add to.
-	@param children	Children to add.
-	@return			Passed element with children added to the end.
+    @param node  Element to add to.
+    @param children Children to add.
+    @return   Passed element with children added to the end.
 *)
 let add_children node children =
-	match node with
-	  ELT (name, attrs, orig_children)
-	  	-> ELT (name, attrs, List.append orig_children children)
-	| _ -> raise (Invalid_argument "not an element")
+  match node with
+  | ELT (name, attrs, orig_children) ->
+    ELT (name, attrs, List.append orig_children children)
+  | _ -> raise (Invalid_argument "not an element")
 
 
 (** Escape the given attribute value for output.
-	@param text		Text of the attribute.
-	@param quote	Quote character used for the attribute, either '"' or '\''.
+    @param text  Text of the attribute.
+    @param quote Quote character used for the attribute, either '"' or '\''.
 *)
 let escape_attr text quote =
-	let buf = Buffer.create 32 in
-	let rec perform i =
-		if i >= String.length text then Buffer.contents buf else
-		begin
-			(match String.get text i with
-			  '&'
-				-> Buffer.add_string buf "&amp;"
-			| '<'
-				-> Buffer.add_string buf "&lt;"
-			| c when c = quote
-				-> Buffer.add_string buf
-					(if quote = '"' then "&quote;" else "&apos;")
-			| c
-				-> Buffer.add_char buf c);
-			perform (i + 1)
-		end in
-	perform 0
+  let buf = Buffer.create 32 in
+  let rec perform i =
+    if i >= String.length text then Buffer.contents buf else
+      begin
+        (match String.get text i with
+           '&'
+           -> Buffer.add_string buf "&amp;"
+         | '<'
+           -> Buffer.add_string buf "&lt;"
+         | c when c = quote
+           -> Buffer.add_string buf
+                (if quote = '"' then "&quote;" else "&apos;")
+         | c
+           -> Buffer.add_char buf c);
+        perform (i + 1)
+      end in
+  perform 0
 
 
 (** Output an attribute.
-	@param out	Output channel.
-	@param name	Name of the attribute.
-	@param text Value of the attribute.
+    @param out Output channel.
+    @param name Name of the attribute.
+    @param text Value of the attribute.
 *)
 let output_attr out (name, text) =
-	output_char out ' ';
-	output_string out name;
-	output_string out "=\"";
-	output_string out (escape_attr text '"');
-	output_char out '"'
+  output_char out ' ';
+  output_string out name;
+  output_string out "=\"";
+  output_string out (escape_attr text '"');
+  output_char out '"'
 
 
 (** Output a node on the given channel.
-	@param out		Channel to output to.
-	@param node		Node to output.
-	@param indent	Indentation.
+    @param out  Channel to output to.
+    @param node  Node to output.
+    @param indent Indentation.
 *)
 let rec output_node out indent node =
-	let output str = output_string out str in
-	let rec only_text children =
-		match children with
-		  [] -> true
-		| (TEXT _)::tl -> only_text tl
-		| _ -> false in
-	match node with
-	
-	  TEXT text
-		-> output text
-		
-	| COM text
-		-> begin
-			output indent;
-			output "<!--";
-			output text;
-			output "-->"
-		end
-		
-	| PI (id, data)
-		-> begin
-			output indent;
-			output "<!";
-			output id;
-			output " ";
-			output data;
-			output ">"
-		end
-		
-	| ELT(name, attrs, children)
-		-> begin
-			output indent;
-			output "<";
-			output name;
-			List.iter (output_attr out) attrs;
-			if children = []
-				then output "/>"
-				else begin
-					output ">";
-					List.iter (output_node out (indent ^ "\t")) children;
-					if not (only_text children)  then output indent;
-					output "</";
-					output name;
-					output ">"
-				end;
-		end	
+  let output str = output_string out str in
+  let rec only_text children =
+    match children with
+      [] -> true
+    | (TEXT _)::tl -> only_text tl
+    | _ -> false in
+  match node with
+
+    TEXT text
+    -> output text
+
+  | COM text
+    -> begin
+        output indent;
+        output "<!--";
+        output text;
+        output "-->"
+      end
+
+  | PI (id, data)
+    -> begin
+        output indent;
+        output "<!";
+        output id;
+        output " ";
+        output data;
+        output ">"
+      end
+
+  | ELT(name, attrs, children)
+    -> begin
+        output indent;
+        output "<";
+        output name;
+        List.iter (output_attr out) attrs;
+        if children = []
+        then output "/>"
+        else begin
+          output ">";
+          List.iter (output_node out (indent ^ "\t")) children;
+          if not (only_text children)  then output indent;
+          output "</";
+          output name;
+          output ">"
+        end;
+      end
 
 
 (** Output an XML document to the given output channel.
-	@param out	Output channel.
-	@param doc	Document to output.
- *)
+    @param out Output channel.
+    @param doc Document to output.
+*)
 let output_doc out doc =
-	output_string out "<?xml version=\"";
-	output_string out doc.version;
-	output_string out "\" encoding=\"";
-	output_string out doc.encoding;
-	output_string out "\" standalone=\"";
-	output_string out (if doc.standalone then "yes" else "no");
-	output_string out "\"?>";
-	output_node out "\n" doc.element;
-	output_char out '\n'
+  output_string out "<?xml version=\"";
+  output_string out doc.version;
+  output_string out "\" encoding=\"";
+  output_string out doc.encoding;
+  output_string out "\" standalone=\"";
+  output_string out (if doc.standalone then "yes" else "no");
+  output_string out "\"?>";
+  output_node out "\n" doc.element;
+  output_char out '\n'
 
 
 (** Output the given XML document on the standard output.
-	@param doc	XML document to output.
+    @param doc XML document to output.
 *)
 let output doc = output_doc stdout doc
 
 
 (** Output the given XML document on the named file.
-	@param filename		Path to the file to write to.
-	@param doc			XML document to output.
-	@raise Sys_error	In case of error during opening of the file.
+    @param filename  Path to the file to write to.
+    @param doc   XML document to output.
+    @raise Sys_error In case of error during opening of the file.
 *)
-let output_file filename doc = 
-	let out = open_out filename in
-	output_doc out doc;
-	close_out out
-
-
-
-
+let output_file filename doc =
+  let out = open_out filename in
+  output_doc out doc;
+  close_out out

--- a/test.t/run.t
+++ b/test.t/run.t
@@ -43,6 +43,8 @@
 
 
 
+
+
   $ ../printc/printc_bin.exe for.c
   
   void main()
@@ -58,6 +60,8 @@
   	}
   }
   
+
+
 
 
 
@@ -100,6 +104,8 @@
   		;
   }
   
+
+
 
 
 
@@ -203,6 +209,8 @@
 
 
 
+
+
   $ echo 'typedef char uint8_t; typedef char uint8_t; typedef char uint8_t; void foo(uint8_t x);' |  ../printc/printc_bin.exe
   
   typedef char uint8_t;
@@ -213,19 +221,3 @@
   
   void foo(uint8_t x);
 
-
-  $ echo 'typedef char uint8_t; typedef char uint8_t; typedef char uint8_t; void foo(uint8_t x);' |  ../ctoxml/ctoxml_bin.exe
-  <?xml version="1.0" encoding="iso-8859-1" standalone="yes"?>
-  <file>
-  	<type id="uint8_t" store="auto">
-  		<char/>
-  	</type>
-  	<fundec id="foo" store="auto">
-  		<type>
-  			<void/>
-  		</type>
-  		<param name="x" store="auto">
-  			<type ref="uint8_t"/>
-  		</param>
-  	</fundec>
-  </file>

--- a/test.t/run.t
+++ b/test.t/run.t
@@ -39,6 +39,10 @@
 
 
 
+
+
+
+
   $ ../printc/printc_bin.exe for.c
   
   void main()
@@ -54,6 +58,10 @@
   	}
   }
   
+
+
+
+
 
 
 
@@ -92,6 +100,10 @@
   		;
   }
   
+
+
+
+
 
 
 
@@ -187,12 +199,33 @@
 
 
 
+
+
+
+
   $ echo 'typedef char uint8_t; typedef char uint8_t; typedef char uint8_t; void foo(uint8_t x);' |  ../printc/printc_bin.exe
   
   typedef char uint8_t;
   
-  typedef char uint8_t$1;
+  typedef char uint8_t;
   
-  typedef char uint8_t$2;
+  typedef char uint8_t;
   
   void foo(uint8_t x);
+
+
+  $ echo 'typedef char uint8_t; typedef char uint8_t; typedef char uint8_t; void foo(uint8_t x);' |  ../ctoxml/ctoxml_bin.exe
+  <?xml version="1.0" encoding="iso-8859-1" standalone="yes"?>
+  <file>
+  	<type id="uint8_t" store="auto">
+  		<char/>
+  	</type>
+  	<fundec id="foo" store="auto">
+  		<type>
+  			<void/>
+  		</type>
+  		<param name="x" store="auto">
+  			<type ref="uint8_t"/>
+  		</param>
+  	</fundec>
+  </file>

--- a/test.t/run.t
+++ b/test.t/run.t
@@ -37,6 +37,8 @@
 
 
 
+
+
   $ ../printc/printc_bin.exe for.c
   
   void main()
@@ -52,6 +54,8 @@
   	}
   }
   
+
+
 
 
 
@@ -88,6 +92,8 @@
   		;
   }
   
+
+
 
 
 
@@ -179,3 +185,14 @@
   }
   
 
+
+
+  $ echo 'typedef char uint8_t; typedef char uint8_t; typedef char uint8_t; void foo(uint8_t x);' |  ../printc/printc_bin.exe
+  
+  typedef char uint8_t;
+  
+  typedef char uint8_t$1;
+  
+  typedef char uint8_t$2;
+  
+  void foo(uint8_t x);


### PR DESCRIPTION
Fixes #9.

ISO/IEC 9899:1999 doesn't allow redefining a type with typedef.

But C11 standard allows redeclaration of typedef names. 6.7/3 says:
```
    ... a typedef name may be redefined to denote the same type as it
    currently does, provided that type is not a variably modified
    type; ...
```

The issue is that duplicated typedefs would generate invalid XML
documents if we will just allow them in the grammar, e.g.,
```

$ echo 'typedef char uint8_t; typedef char uint8_t; void foo(uint8_t);' | ctoxml
<?xml version="1.0" encoding="iso-8859-1" standalone="yes"?>
<file>
    <type id="uint8_t" store="auto">
        <char/>
    </type>
    <type id="uint8_t" store="auto">
        <char/>
    </type>
    <fundec id="foo" store="auto">
        <type>
            <void/>
        </type>
        <param name="" store="auto">
            <type ref="uint8_t"/>
        </param>
    </fundec>
</file>
```

To prevent this, we added an efficient deduplication procedure. This procedure is useful by itself as even before this change the generated XML could be invalid, for example, when several prototypes of the same function occur in the stream (a quite common situation). 

At the end we have the following behavior (snippets are taken from our cram tests)

```
  $ echo 'typedef char uint8_t; typedef char uint8_t; typedef char uint8_t; void foo(uint8_t x);' |  ../printc/printc_bin.exe
  
  typedef char uint8_t;
  
  typedef char uint8_t;
  
  typedef char uint8_t;
  
  void foo(uint8_t x);


  $ echo 'typedef char uint8_t; typedef char uint8_t; typedef char uint8_t; void foo(uint8_t x);' |  ../ctoxml/ctoxml_bin.exe
  <?xml version="1.0" encoding="iso-8859-1" standalone="yes"?>
  <file>
  	<type id="uint8_t" store="auto">
  		<char/>
  	</type>
  	<fundec id="foo" store="auto">
  		<type>
  			<void/>
  		</type>
  		<param name="x" store="auto">
  			<type ref="uint8_t"/>
  		</param>
  	</fundec>
  </file>
```