### PR TITLE
removes all conflicts and cleans up the grammar

### DIFF
--- a/ctoxml/test.t/run.t
+++ b/ctoxml/test.t/run.t
@@ -3865,3 +3865,13 @@
   		</param>
   	</fundec>
   </file>
+
+  $ echo 'struct foo {int x;};' | dune exec ctoxml
+  <?xml version="1.0" encoding="iso-8859-1" standalone="yes"?>
+  <file>
+  	<struct id="struct:foo">
+  		<field name="x">
+  			<long/>
+  		</field>
+  	</struct>
+  </file>

--- a/frontc/cabs.ml
+++ b/frontc/cabs.ml
@@ -6,69 +6,69 @@ exception BadType
 
 (**
  * Thrown when an unconsistent C abstract syntax is found.
- *)
+*)
 exception UnconsistentDef
 
 
 (** Size of int *)
 type size =
-	  NO_SIZE		(** No size modifier *)
-	| SHORT			(** "short" modifier *)
-	| LONG			(** "long" modifier *)
-	| LONG_LONG		(** GNU "long long" modifier *)
+    NO_SIZE  (** No size modifier *)
+  | SHORT   (** "short" modifier *)
+  | LONG   (** "long" modifier *)
+  | LONG_LONG  (** GNU "long long" modifier *)
 
 (** Signess of int and bitfields *)
 and sign =
-	  NO_SIGN		(** No sign modifier *)
-	| SIGNED		(** "signed" modifier *)
-	| UNSIGNED		(** "unsigned" modifier *)
+    NO_SIGN  (** No sign modifier *)
+  | SIGNED  (** "signed" modifier *)
+  | UNSIGNED  (** "unsigned" modifier *)
 
 (** Storage of names *)
 and storage =
-	  NO_STORAGE	(** No storage modifier *)
-	| AUTO			(** "auto" modifier *)
-	| STATIC		(** "static" modifier *)
-	| EXTERN		(** "extern" modifier *)
-	| REGISTER		(** "register" modifier *)
+    NO_STORAGE (** No storage modifier *)
+  | AUTO   (** "auto" modifier *)
+  | STATIC  (** "static" modifier *)
+  | EXTERN  (** "extern" modifier *)
+  | REGISTER  (** "register" modifier *)
 
 
 (** Base type *)
 and base_type =
-	  NO_TYPE				(** Old K&R declaration without type *)
-	| VOID					(** "void" type *)
-	| CHAR of sign			(** "char" type with sign modifier *)
-	| INT of size * sign	(** "int" type with size and sign modifiers *)
-	| BITFIELD of sign * expression
-		(** Bitfield with sign modifier and size expression *)
-	| FLOAT of bool				(** "float" type with long (true) modifier *)
-	| DOUBLE of bool			(** "doubl" type with long (true) modifier *)
-	| PTR of base_type			(** Pointer "*" to the given type *)
-	| RESTRICT_PTR of base_type	(** REstricted pointer "*" to the given type. *)
-	| ARRAY of base_type * expression
-		(** Array of the given type with the given expression size (may be NOTHING) *)
-	| STRUCT of string * name_group list
-		(** "struct" of the given name (may be empty) with given fields (may also be empty) *)
-	| UNION of string * name_group list
-		(** "union" of the given name (may be empty) with given fields (may also be empty) *)
-	| PROTO of proto		(** Prototype of a function *)
-	| OLD_PROTO of old_proto	(** Old-style K&R prototype *)
-	| NAMED_TYPE of string		(** Named type coming from typedef *)
-	| ENUM of string * enum_item list
-		(** "union" of the given name (may be empty) with given values (may also be empty) *)
-	| CONST of base_type
-		(** "const" modifier *)
-	| VOLATILE of base_type
-		(** "volatile" modifier *)
-	| GNU_TYPE of gnu_attrs * base_type
-		(** Not a type, just to record the file/line of an identifier. *)
-	| TYPE_LINE of string * int * base_type
+    NO_TYPE    (** Old K&R declaration without type *)
+  | VOID     (** "void" type *)
+  | CHAR of sign   (** "char" type with sign modifier *)
+  | INT of size * sign (** "int" type with size and sign modifiers *)
+  | BITFIELD of sign * expression
+  (** Bitfield with sign modifier and size expression *)
+  | FLOAT of bool    (** "float" type with long (true) modifier *)
+  | DOUBLE of bool   (** "doubl" type with long (true) modifier *)
+  | PTR of base_type   (** Pointer "*" to the given type *)
+  | RESTRICT_PTR of base_type (** REstricted pointer "*" to the given type. *)
+  | ARRAY of base_type * expression
+  (** Array of the given type with the given expression size (may be NOTHING) *)
+  | STRUCT of string * name_group list
+  (** "struct" of the given name (may be empty) with given fields (may also be empty) *)
+  | UNION of string * name_group list
+  (** "union" of the given name (may be empty) with given fields (may also be empty) *)
+  | PROTO of proto  (** Prototype of a function *)
+  | OLD_PROTO of old_proto (** Old-style K&R prototype *)
+  | NAMED_TYPE of string  (** Named type coming from typedef *)
+  | ENUM of string * enum_item list
+  (** "union" of the given name (may be empty) with given values (may also be empty) *)
+  | CONST of base_type
+  (** "const" modifier *)
+  | VOLATILE of base_type
+  (** "volatile" modifier *)
+  | GNU_TYPE of gnu_attrs * base_type
+  (** Not a type, just to record the file/line of an identifier. *)
+  | TYPE_LINE of string * int * base_type
 
 (** A name in a declaration with identifier, full type, GNU attributes and
- *	initialization expression. *)
+ * initialization expression. *)
 and name = string * base_type * gnu_attrs * expression
 
 (** A name group, that is, a simple type following by many name
- *	declaration as [int v, *p, t\[256\];]. *)
+ * declaration as [int v, *p, t\[256\];]. *)
 and name_group = base_type * storage * name list
 
 (** A single name, as above, but with only one declaration. *)
@@ -78,188 +78,188 @@ and single_name = base_type * storage * name
 and enum_item = string * expression
 
 (** Prototype of a function with return type, function declaration and
- *	variable argument "..." boolean. *)
+ * variable argument "..." boolean. *)
 and proto = base_type * single_name list * bool
 
 (** Old-C K&R function prototype with root type, list of arguments and
- *	variable argument "..." boolean. *)
+ * variable argument "..." boolean. *)
 and old_proto = base_type * string list * bool
 
 
 (** Definitions found in a C file. *)
 and definition =
-	FUNDEF of single_name * body
-		(** Definition of a function. *)
-	| OLDFUNDEF of single_name * name_group list * body
-		(** Definition of an old-C K&R style function. *)
-	| DECDEF of name_group
-		(** Declaration of function or definition of a variable. *)
-	| TYPEDEF of name_group * gnu_attrs
-		(** Definition of a typedef. *)
-	| ONLYTYPEDEF of name_group
-		(** Definition of lonely "struct", "union" or "enum". *)
+  | FUNDEF of single_name * body
+  (** Definition of a function. *)
+  | OLDFUNDEF of single_name * name_group list * body
+  (** Definition of an old-C K&R style function. *)
+  | DECDEF of name_group
+  (** Declaration of function or definition of a variable. *)
+  | TYPEDEF of name_group * gnu_attrs
+  (** Definition of a typedef. *)
+  | ONLYTYPEDEF of name_group
+  (** Definition of lonely "struct", "union" or "enum". *)
 
 (** A C files is composed of C definitions *)
 and file = definition list
 
 
 (** The body of a function is composed as a list of variable declaration
- *	and of a statement. *)
+ * and of a statement. *)
 and body = definition list * statement
 
 
 (** Statement changes the flow of control. *)
 and statement =
-	  NOP
-	  	(** No operation. Useful for empty else-part in condition. *)
-	| COMPUTATION of expression
-		(** A simple expression, usually an assignment. *)
-	| BLOCK of body
-		(** A block between braces *)
-	| SEQUENCE of statement * statement
-		(** Two statement separated by ";" *)
-	| IF of expression * statement * statement
-		(** "if" statement with or without else-part. *)
-	| WHILE of expression * statement
-		(** "while" statement. *)
-	| DOWHILE of expression * statement
-		(** "do ... while" statement *)
-	| FOR of expression * expression * expression * statement
-		(** "for" statement. *)
-	| BREAK
-		(** "break" statement. *)
-	| CONTINUE
-		(** "continue" statement. *)
-	| RETURN of expression
-		(** "return" statement with an expression or with NOTHING. *)
-	| SWITCH of expression * statement
-		(** "switch" statement. Cases are put in the sub-statement as labels. *)
-	| CASE of expression * statement
-		(** "case" statement as a label. *)
-	| DEFAULT of statement
-		(** "default" statement as a label. *)
-	| LABEL of string * statement
-		(** "label" statement whose sub-statement follows colon ":". *)
-	| GOTO of string
-		(** "goto" statement. *)
-	| ASM of string
-		(** Classical "asm" support. *)
-	| GNU_ASM of string * gnu_asm_arg list * gnu_asm_arg list * string list
-		(** GNU "asm" support. *)
-	| STAT_LINE of statement * string * int
-		(** Information the filename and the line number of the contained statement. *)
+    NOP
+  (** No operation. Useful for empty else-part in condition. *)
+  | COMPUTATION of expression
+  (** A simple expression, usually an assignment. *)
+  | BLOCK of body
+  (** A block between braces *)
+  | SEQUENCE of statement * statement
+  (** Two statement separated by ";" *)
+  | IF of expression * statement * statement
+  (** "if" statement with or without else-part. *)
+  | WHILE of expression * statement
+  (** "while" statement. *)
+  | DOWHILE of expression * statement
+  (** "do ... while" statement *)
+  | FOR of expression * expression * expression * statement
+  (** "for" statement. *)
+  | BREAK
+  (** "break" statement. *)
+  | CONTINUE
+  (** "continue" statement. *)
+  | RETURN of expression
+  (** "return" statement with an expression or with NOTHING. *)
+  | SWITCH of expression * statement
+  (** "switch" statement. Cases are put in the sub-statement as labels. *)
+  | CASE of expression * statement
+  (** "case" statement as a label. *)
+  | DEFAULT of statement
+  (** "default" statement as a label. *)
+  | LABEL of string * statement
+  (** "label" statement whose sub-statement follows colon ":". *)
+  | GOTO of string
+  (** "goto" statement. *)
+  | ASM of string
+  (** Classical "asm" support. *)
+  | GNU_ASM of string * gnu_asm_arg list * gnu_asm_arg list * string list
+  (** GNU "asm" support. *)
+  | STAT_LINE of statement * string * int
+  (** Information the filename and the line number of the contained statement. *)
 
 and gnu_asm_arg =  string * string * expression
 
 (* Binary operators identifiers. *)
 and binary_operator =
-	  ADD				(** "+" operator. *)
-	| SUB				(** "-" operator. *)
-	| MUL				(** "*" operator. *)
-	| DIV				(** "/" operator. *)
-	| MOD				(** "%" operator. *)
-	| AND				(** "&&" operator. *)
-	| OR				(** "||" operator. *)
-	| BAND				(** "&" operator. *)
-	| BOR				(** "|" operator. *)
-	| XOR				(** "^" operator. *)
-	| SHL				(** "<<" operator. *)
-	| SHR				(** ">>" operator. *)
-	| EQ				(** "==" operator. *)
-	| NE				(** "!=" operator. *)
-	| LT				(** "<" operator. *)
-	| GT				(** ">" operator. *)
-	| LE				(** "<=" operator. *)
-	| GE				(** ">=" operator. *)
-	| ASSIGN			(** "=" operator. *)
-	| ADD_ASSIGN		(** "+=" operator. *)
-	| SUB_ASSIGN		(** "-=" operator. *)
-	| MUL_ASSIGN		(** "*=" operator. *)
-	| DIV_ASSIGN		(** "/=" operator. *)
-	| MOD_ASSIGN		(** "%=" operator. *)
-	| BAND_ASSIGN		(** "&=" operator. *)
-	| BOR_ASSIGN		(** "|=" operator. *)
-	| XOR_ASSIGN		(** "^=" operator. *)
-	| SHL_ASSIGN		(** "<<=" operator. *)
-	| SHR_ASSIGN		(** ">>=" operator. *)
+    ADD    (** "+" operator. *)
+  | SUB    (** "-" operator. *)
+  | MUL    (** "*" operator. *)
+  | DIV    (** "/" operator. *)
+  | MOD    (** "%" operator. *)
+  | AND    (** "&&" operator. *)
+  | OR    (** "||" operator. *)
+  | BAND    (** "&" operator. *)
+  | BOR    (** "|" operator. *)
+  | XOR    (** "^" operator. *)
+  | SHL    (** "<<" operator. *)
+  | SHR    (** ">>" operator. *)
+  | EQ    (** "==" operator. *)
+  | NE    (** "!=" operator. *)
+  | LT    (** "<" operator. *)
+  | GT    (** ">" operator. *)
+  | LE    (** "<=" operator. *)
+  | GE    (** ">=" operator. *)
+  | ASSIGN   (** "=" operator. *)
+  | ADD_ASSIGN  (** "+=" operator. *)
+  | SUB_ASSIGN  (** "-=" operator. *)
+  | MUL_ASSIGN  (** "*=" operator. *)
+  | DIV_ASSIGN  (** "/=" operator. *)
+  | MOD_ASSIGN  (** "%=" operator. *)
+  | BAND_ASSIGN  (** "&=" operator. *)
+  | BOR_ASSIGN  (** "|=" operator. *)
+  | XOR_ASSIGN  (** "^=" operator. *)
+  | SHL_ASSIGN  (** "<<=" operator. *)
+  | SHR_ASSIGN  (** ">>=" operator. *)
 
 (** Unary operators identifiers. *)
 and unary_operator =
-	  MINUS		(** "-" operator. *)
-	| PLUS		(** "+" operator. *)
-	| NOT		(** "!" operator. *)
-	| BNOT		(** "~" operator. *)
-	| MEMOF		(** "*" operator. *)
-	| ADDROF	(** "&" operator. *)
-	| PREINCR	(** "++" pre-incrementation. *)
-	| PREDECR	(** "--" pre-decrementation. *)
-	| POSINCR	(** "++" post-incrementation. *)
-	| POSDECR	(** "--" post-decrementation. *)
+    MINUS  (** "-" operator. *)
+  | PLUS  (** "+" operator. *)
+  | NOT  (** "!" operator. *)
+  | BNOT  (** "~" operator. *)
+  | MEMOF  (** "*" operator. *)
+  | ADDROF (** "&" operator. *)
+  | PREINCR (** "++" pre-incrementation. *)
+  | PREDECR (** "--" pre-decrementation. *)
+  | POSINCR (** "++" post-incrementation. *)
+  | POSDECR (** "--" post-decrementation. *)
 
 (** Expressions. *)
 and expression =
-	NOTHING
-		(** Null-expression. Useful for return with no value or table
-		declaration without size. *)
-	| UNARY of unary_operator * expression
-		(** Unary operator use. *)
-	| BINARY of binary_operator * expression * expression
-		(** Binary operator use. *)
-	| QUESTION of expression * expression * expression
-		(** "condition ? then-expression : else-expression" operator. *)
-	| CAST of base_type * expression
-		(** "(type)expresson" type casting. *)
-	| CALL of expression * expression list
-		(** Function call. *)
-	| COMMA of expression list
-		(** Sequence of expression separated with ",". *)
-	| CONSTANT of constant
-		(** Constant value. *)
-	| VARIABLE of string
-		(** Access to an identifier. *)
-	| EXPR_SIZEOF of expression
-		(** "sizeof" with expression. *)
-	| TYPE_SIZEOF of base_type
-		(** "sizeof" with type. *)
-	| INDEX of expression * expression
-		(** Access to an array item; *)
-	| MEMBEROF of expression * string
-		(** Indirection through ".". *)
-	| MEMBEROFPTR of expression * string
-		(** Pointer indirection through "->". *)
-	| GNU_BODY of body
-		(** GNU braces inside an expression. *)
-	| EXPR_LINE of expression * string * int
-		(** Record the file and line of the expression. *)
+    NOTHING
+  (** Null-expression. Useful for return with no value or table
+      declaration without size. *)
+  | UNARY of unary_operator * expression
+  (** Unary operator use. *)
+  | BINARY of binary_operator * expression * expression
+  (** Binary operator use. *)
+  | QUESTION of expression * expression * expression
+  (** "condition ? then-expression : else-expression" operator. *)
+  | CAST of base_type * expression
+  (** "(type)expresson" type casting. *)
+  | CALL of expression * expression list
+  (** Function call. *)
+  | COMMA of expression list
+  (** Sequence of expression separated with ",". *)
+  | CONSTANT of constant
+  (** Constant value. *)
+  | VARIABLE of string
+  (** Access to an identifier. *)
+  | EXPR_SIZEOF of expression
+  (** "sizeof" with expression. *)
+  | TYPE_SIZEOF of base_type
+  (** "sizeof" with type. *)
+  | INDEX of expression * expression
+  (** Access to an array item; *)
+  | MEMBEROF of expression * string
+  (** Indirection through ".". *)
+  | MEMBEROFPTR of expression * string
+  (** Pointer indirection through "->". *)
+  | GNU_BODY of body
+  (** GNU braces inside an expression. *)
+  | EXPR_LINE of expression * string * int
+  (** Record the file and line of the expression. *)
 
 (** Constant values. *)
 and constant =
-	| CONST_INT of string
-		(** Integer constant. *)
-	| CONST_FLOAT of string
-		(** Float constant. *)
-	| CONST_CHAR of string
-		(** Character constant with escapes resolved. *)
-	| CONST_STRING of string
-		(** String constant with escapes resolved. *)
-	| CONST_COMPOUND of expression list
-		(** Compound values between braces. Only valid for variable
-		initialization. *)
+  | CONST_INT of string
+  (** Integer constant. *)
+  | CONST_FLOAT of string
+  (** Float constant. *)
+  | CONST_CHAR of string
+  (** Character constant with escapes resolved. *)
+  | CONST_STRING of string
+  (** String constant with escapes resolved. *)
+  | CONST_COMPOUND of expression list
+  (** Compound values between braces. Only valid for variable
+      initialization. *)
 
 (** GNU special attribute list.*)
 and gnu_attrs = gnu_attr list
 
 (** GNU special attribute. *)
 and gnu_attr =
-	  GNU_NONE
-	  	(** No attribute "()". *)
-	| GNU_CALL of string * gnu_attr list
-		(** Function call. *)
-	| GNU_ID of string
-		(** Single identifier. *)
-	| GNU_CST of constant
-		(** Constant value. *)
-	| GNU_EXTENSION
-		(** Support of __extension__ keyword *)
-	| GNU_INLINE
-		(** Support of __inline keyword *)
+    GNU_NONE
+  (** No attribute "()". *)
+  | GNU_CALL of string * gnu_attr list
+  (** Function call. *)
+  | GNU_ID of string
+  (** Single identifier. *)
+  | GNU_CST of constant
+  (** Constant value. *)
+  | GNU_EXTENSION
+  (** Support of __extension__ keyword *)
+  | GNU_INLINE
+  (** Support of __inline keyword *)

--- a/frontc/clexer.mll
+++ b/frontc/clexer.mll
@@ -141,6 +141,7 @@ let keywords =
     ("signed", id SIGNED);
     ("unsigned", id UNSIGNED);
     ("volatile", id VOLATILE);
+    ("inline", id INLINE);
     ("__restrict", id RESTRICT);
     ("restrict", id RESTRICT);
     ("char", id CHAR);

--- a/frontc/cparser.mly
+++ b/frontc/cparser.mly
@@ -509,10 +509,8 @@ typedef_dec:
 
 
 /*** Field Definition ***/
-field_list:
-field_list field    {$2::$1}
-  |  field       {[$1]}
-;
+field_list: field* {$1};
+
 field:
 field_type field_defs SEMICOLON {set_name_group $1 (List.rev $2)}
 ;
@@ -542,16 +540,11 @@ qual_type      {$1}
   |  field_qual qual_type   {apply_qual $1 $2}
   |  field_qual field_mod   {(fst $1, $2::(snd $1))}
 ;
-field_defs:
-  | field_defs COMMA field_def  {$3::$1}
-  |  field_def      {[$1]}
-;
-field_def:
-field_dec      {(fst $1, snd $1, [], NOTHING)}
-;
+field_defs: separated_nonempty_list(COMMA, field_def) {$1};
+
+field_def: field_dec {(fst $1, snd $1, [], NOTHING)} ;
+
 field_dec:
-/* emtpy */
-    {("", NO_TYPE)}
   |  IDENT
     {($1, NO_TYPE)}
   |  NAMED_TYPE

--- a/frontc/cparser.mly
+++ b/frontc/cparser.mly
@@ -21,60 +21,60 @@
     let apply_mod (typ, sto) modi =
       let rec mod_root typ =
 	match (typ, modi) with
-	  (NO_TYPE, BASE_SIGN sign) -> INT (NO_SIZE, sign)
-	| (NO_TYPE, BASE_SIZE size) -> INT (size, NO_SIGN)
-	| (CHAR NO_SIGN, BASE_SIGN sign) -> CHAR sign
-	| (INT (NO_SIZE, sign), BASE_SIZE size) -> INT (size, sign)
-	| (INT (LONG, sign), BASE_SIZE LONG) -> INT (LONG_LONG, sign)
-	| (INT (size, NO_SIGN), BASE_SIGN sign) -> INT (size, sign)
-	| (BITFIELD (NO_SIGN, exp), BASE_SIGN sign) -> BITFIELD (sign, exp)
-	| (FLOAT false, BASE_SIZE LONG) -> FLOAT true
-	| (DOUBLE false, BASE_SIZE LONG) -> DOUBLE true
-	| (PTR typ, _) -> PTR (mod_root typ)
-	| (CONST typ, _) -> CONST (mod_root typ)
-	| (VOLATILE typ, _) -> VOLATILE (mod_root typ)
-	| (GNU_TYPE (attrs, typ), _) -> GNU_TYPE (attrs, mod_root typ)
-	| (TYPE_LINE (f, l, t), _) -> TYPE_LINE (f, l, mod_root t)
-	| _ -> raise BadModifier in
+          (NO_TYPE, BASE_SIGN sign) -> INT (NO_SIZE, sign)
+        | (NO_TYPE, BASE_SIZE size) -> INT (size, NO_SIGN)
+        | (CHAR NO_SIGN, BASE_SIGN sign) -> CHAR sign
+        | (INT (NO_SIZE, sign), BASE_SIZE size) -> INT (size, sign)
+        | (INT (LONG, sign), BASE_SIZE LONG) -> INT (LONG_LONG, sign)
+        | (INT (size, NO_SIGN), BASE_SIGN sign) -> INT (size, sign)
+        | (BITFIELD (NO_SIGN, exp), BASE_SIGN sign) -> BITFIELD (sign, exp)
+        | (FLOAT false, BASE_SIZE LONG) -> FLOAT true
+        | (DOUBLE false, BASE_SIZE LONG) -> DOUBLE true
+        | (PTR typ, _) -> PTR (mod_root typ)
+        | (CONST typ, _) -> CONST (mod_root typ)
+        | (VOLATILE typ, _) -> VOLATILE (mod_root typ)
+        | (GNU_TYPE (attrs, typ), _) -> GNU_TYPE (attrs, mod_root typ)
+        | (TYPE_LINE (f, l, t), _) -> TYPE_LINE (f, l, mod_root t)
+        | _ -> raise BadModifier in
       let check_access typ =
-	match typ with
-	  PROTO _ | OLD_PROTO _ | CONST _ | VOLATILE _ -> false
-	  | _ -> true in
+        match typ with
+          PROTO _ | OLD_PROTO _ | CONST _ | VOLATILE _ -> false
+          | _ -> true in
       match modi with
-	BASE_SIGN _ -> (mod_root typ, sto)
+        BASE_SIGN _ -> (mod_root typ, sto)
       | BASE_SIZE _ -> (mod_root typ, sto)
       | BASE_CONST ->
-	 if (check_access typ) then (CONST typ, sto)
-	 else raise BadModifier
+         if (check_access typ) then (CONST typ, sto)
+         else raise BadModifier
       | BASE_VOLATILE ->
-	 if (check_access typ) then (VOLATILE typ, sto)
-	 else raise BadModifier
+         if (check_access typ) then (VOLATILE typ, sto)
+         else raise BadModifier
       | BASE_STORAGE sto' ->
-	 if sto = NO_STORAGE then (typ, sto')
-	 else raise BadModifier
+         if sto = NO_STORAGE then (typ, sto')
+         else raise BadModifier
       | BASE_GNU_ATTR attrs ->
-	 (GNU_TYPE (attrs, typ), sto)
+         (GNU_TYPE (attrs, typ), sto)
 
     let apply_mods mods fty =
       List.fold_left apply_mod fty mods
 
     let set_type tst tin =
       let rec set typ =
-	match typ with
-	  NO_TYPE -> tst
-	| PTR typ -> PTR (set typ)
-	| RESTRICT_PTR typ -> RESTRICT_PTR (set typ)
-	| ARRAY (typ, dim) -> ARRAY (set typ, dim)
-	| PROTO (typ, pars, ell) -> PROTO (set typ, pars, ell)
-	| OLD_PROTO (typ, pars, ell) -> OLD_PROTO (set typ, pars, ell)
-	| CONST typ -> CONST (set typ)
-	| VOLATILE typ -> VOLATILE (set typ)
-	| TYPE_LINE (f, l, t) -> TYPE_LINE (f, l, set t)
-	| BITFIELD (NO_SIGN, exp) ->
-	   (match tst with
-	      INT (_, sign) -> BITFIELD (sign, exp)
-	    | _ -> raise BadType)
-	| _ -> raise BadType in
+        match typ with
+          NO_TYPE -> tst
+        | PTR typ -> PTR (set typ)
+        | RESTRICT_PTR typ -> RESTRICT_PTR (set typ)
+        | ARRAY (typ, dim) -> ARRAY (set typ, dim)
+        | PROTO (typ, pars, ell) -> PROTO (set typ, pars, ell)
+        | OLD_PROTO (typ, pars, ell) -> OLD_PROTO (set typ, pars, ell)
+        | CONST typ -> CONST (set typ)
+        | VOLATILE typ -> VOLATILE (set typ)
+        | TYPE_LINE (f, l, t) -> TYPE_LINE (f, l, set t)
+        | BITFIELD (NO_SIGN, exp) ->
+           (match tst with
+              INT (_, sign) -> BITFIELD (sign, exp)
+            | _ -> raise BadType)
+        | _ -> raise BadType in
       set tin
 
 
@@ -83,12 +83,12 @@
      *)
     let smooth_expression lst =
       match lst with
-	[] -> NOTHING
+        [] -> NOTHING
       | [expr] -> expr
       | _ -> COMMA (List.rev lst)
     let list_expression expr =
       match expr with
-	COMMA lst -> lst
+        COMMA lst -> lst
       | NOTHING -> []
       | _ -> [expr]
 
@@ -105,10 +105,10 @@
       (typ, sto, set_name typ name)
 
     let apply_qual ((t1, q1) : base_type * modifier list)
-	  ((t2, q2) : base_type * modifier list)
-	: base_type * modifier list =
+          ((t2, q2) : base_type * modifier list)
+        : base_type * modifier list =
       ((if t1 = NO_TYPE then t2 else
-	  if t2 = NO_TYPE then t1 else  raise BadModifier),
+          if t2 = NO_TYPE then t1 else  raise BadModifier),
        List.append q1 q2)
 
     (*** Line management ***)
@@ -126,30 +126,29 @@
       if Clexer.linerec !Clexer.current_handle
       then Cabs.TYPE_LINE (Clexer.curfile (), Clexer.curline(), _type)
       else _type
-
 %}
 
 
 /* operator precedence */
-%nonassoc 	IF
-%nonassoc 	ELSE
+%nonassoc  IF
+%nonassoc  ELSE
 
-%right	EQ PLUS_EQ MINUS_EQ STAR_EQ SLASH_EQ PERCENT_EQ
+%right EQ PLUS_EQ MINUS_EQ STAR_EQ SLASH_EQ PERCENT_EQ
 AND_EQ PIPE_EQ CIRC_EQ INF_INF_EQ SUP_SUP_EQ
-%right	QUEST COLON
-%left	PIPE_PIPE
-%left	AND_AND
-%left	PIPE
-%left 	CIRC
-%left	AND
-%left	EQ_EQ EXCLAM_EQ
-%left	INF SUP INF_EQ SUP_EQ
-%left	INF_INF SUP_SUP
-%left	PLUS MINUS
-%left	STAR SLASH PERCENT CONST VOLATILE RESTRICT
-%right	EXCLAM TILDE PLUS_PLUS MINUS_MINUS CAST RPAREN ADDROF
-%left 	LBRACKET
-%left	DOT ARROW LPAREN SIZEOF
+%right QUEST COLON
+%left PIPE_PIPE
+%left AND_AND
+%left PIPE
+%left  CIRC
+%left AND
+%left EQ_EQ EXCLAM_EQ
+%left INF SUP INF_EQ SUP_EQ
+%left INF_INF SUP_SUP
+%left PLUS MINUS
+%left STAR SLASH PERCENT CONST VOLATILE RESTRICT
+%right EXCLAM TILDE PLUS_PLUS MINUS_MINUS CAST RPAREN ADDROF
+%left  LBRACKET
+%left DOT ARROW LPAREN SIZEOF
 
 /* Non-terminals informations */
 %start interpret file
@@ -192,8 +191,8 @@ file:
   | globals EOF {List.rev $1};
 
 globals:
-  | global						{[$1]}
-  | globals global					{$2::$1}
+  | global      {[$1]}
+  | globals global     {$2::$1}
   | error {parse_error $symbolstartofs $endofs}
 ;
 
@@ -202,106 +201,106 @@ globals:
 global:
 global_type global_defs SEMICOLON
     {DECDEF (set_name_group $1 (List.rev $2))}
-  |		global_type global_proto body
+  |  global_type global_proto body
     {
       let (_, base, _, _) = $2 in
       match base with
-	PROTO _ ->
-	 FUNDEF (set_single $1 $2, (snd $3))
+ PROTO _ ->
+  FUNDEF (set_single $1 $2, (snd $3))
       | OLD_PROTO _ ->
-	 OLDFUNDEF (set_single $1 $2, [], (snd $3))
+  OLDFUNDEF (set_single $1 $2, [], (snd $3))
       | _ ->
-	 parse_error $symbolstartofs $endofs
+  parse_error $symbolstartofs $endofs
     }
-  | 	global_type global_proto basic_asm opt_gcc_attributes SEMICOLON
+  |  global_type global_proto basic_asm opt_gcc_attributes SEMICOLON
     {
       let (id, base, attr, exp) = $2 in
       let name = (id, base, attr@$4, exp) in
       match base with
-	PROTO _ ->
-	 FUNDEF (set_single $1 name, ([], $3))
+ PROTO _ ->
+  FUNDEF (set_single $1 name, ([], $3))
       | OLD_PROTO _ ->
-	 OLDFUNDEF (set_single $1 name, [], ([], $3))
+  OLDFUNDEF (set_single $1 name, [], ([], $3))
       | _ ->
-	 parse_error $symbolstartofs $endofs
+  parse_error $symbolstartofs $endofs
     }
-  |		global_type old_proto old_pardefs body
+  |  global_type old_proto old_pardefs body
     { OLDFUNDEF (set_single $1 $2, List.rev $3, (snd $4)) }
-  |		global_type SEMICOLON
+  |  global_type SEMICOLON
     {ONLYTYPEDEF (set_name_group $1 [])}
-  |		TYPEDEF typedef_type typedef_defs SEMICOLON
+  |  TYPEDEF typedef_type typedef_defs SEMICOLON
     {let _ = List.iter (fun (id, _, _, _) -> Clexer.add_type id) $3 in
      TYPEDEF (set_name_group (fst $2, snd $2) $3, [])}
-  |		gcc_attribute TYPEDEF typedef_type typedef_defs SEMICOLON
+  |  gcc_attribute TYPEDEF typedef_type typedef_defs SEMICOLON
     {let _ = List.iter (fun (id, _, _, _) -> Clexer.add_type id) $4 in
      TYPEDEF (set_name_group (fst $3, snd $3) $4, $1)}
 ;
 global_type:
 global_mod_list_opt global_qual
     {apply_mods (snd $2) (apply_mods $1 ((fst $2), NO_STORAGE))}
-  |		global_mod_list_opt comp_type global_mod_list_opt
+  |  global_mod_list_opt comp_type global_mod_list_opt
     {apply_mods $3 (apply_mods $1 ($2, NO_STORAGE))}
-  |		global_mod_list_opt NAMED_TYPE global_mod_list_opt
+  |  global_mod_list_opt NAMED_TYPE global_mod_list_opt
     {apply_mods $3 (apply_mods $1 (NAMED_TYPE $2, NO_STORAGE))}
-  |		global_mod_list_opt
+  |  global_mod_list_opt
     {apply_mods $1 (NO_TYPE, NO_STORAGE)}
 ;
 global_mod_list_opt:
-/* empty */						{[]}
-  |		global_mod_list					{List.rev $1}
+/* empty */      {[]}
+  |  global_mod_list     {List.rev $1}
 ;
 global_mod_list:
-global_mod						{[$1]}
-  |		global_mod_list global_mod		{$2::$1}
+global_mod      {[$1]}
+  |  global_mod_list global_mod  {$2::$1}
 ;
 global_mod:
-STATIC							{BASE_STORAGE STATIC}
-  |		CONST							{BASE_CONST}
-  |		VOLATILE						{BASE_VOLATILE}
-  |		EXTERN							{BASE_STORAGE EXTERN}
-  |		gcc_attribute					{ BASE_GNU_ATTR $1 }
+STATIC       {BASE_STORAGE STATIC}
+  |  CONST       {BASE_CONST}
+  |  VOLATILE      {BASE_VOLATILE}
+  |  EXTERN       {BASE_STORAGE EXTERN}
+  |  gcc_attribute     { BASE_GNU_ATTR $1 }
 ;
 global_qual:
-qual_type						{$1}
-  |		global_qual qual_type			{apply_qual $1 $2}
-  |		global_qual global_mod			{(fst $1, $2::(snd $1))}
+qual_type      {$1}
+  |  global_qual qual_type   {apply_qual $1 $2}
+  |  global_qual global_mod   {(fst $1, $2::(snd $1))}
 ;
 global_defs:
-global_def						{[$1]}
-  |		global_defs COMMA global_def	{$3::$1}
+global_def      {[$1]}
+  |  global_defs COMMA global_def {$3::$1}
 ;
 global_def:
 global_dec opt_gcc_attributes
     {(fst $1, snd $1, $2, NOTHING)}
-  |		global_dec opt_gcc_attributes EQ init_expression
+  |  global_dec opt_gcc_attributes EQ init_expression
     {(fst $1, snd $1, $2, $4)}
 ;
 global_dec:
 IDENT
     {($1, set_tline NO_TYPE)}
-  |		LPAREN global_dec RPAREN
+  |  LPAREN global_dec RPAREN
     {$2}
-  |		STAR global_dec
+  |  STAR global_dec
     {(fst $2, set_type (PTR NO_TYPE) (snd $2))}
-  |		STAR CONST global_dec
+  |  STAR CONST global_dec
     {(fst $3, set_type (CONST (PTR NO_TYPE)) (snd $3))}
-  |		STAR VOLATILE global_dec
+  |  STAR VOLATILE global_dec
     {(fst $3, set_type (VOLATILE (PTR NO_TYPE)) (snd $3))}
-  |		STAR RESTRICT global_dec
+  |  STAR RESTRICT global_dec
     {(fst $3, set_type (RESTRICT_PTR NO_TYPE) (snd $3))}
-  |		STAR gcc_attributes global_dec
+  |  STAR gcc_attributes global_dec
     {(fst $3, set_type (GNU_TYPE ($2, PTR NO_TYPE)) (snd $3))}
-  |		global_dec LBRACKET comma_expression RBRACKET
+  |  global_dec LBRACKET comma_expression RBRACKET
     {(fst $1, set_type (ARRAY (NO_TYPE, smooth_expression $3)) (snd $1))}
-  |		global_dec LBRACKET RBRACKET
+  |  global_dec LBRACKET RBRACKET
     {(fst $1, set_type (ARRAY (NO_TYPE, NOTHING)) (snd $1))}
-  |		global_dec LPAREN parameters RPAREN
+  |  global_dec LPAREN parameters RPAREN
     {(fst $1, PROTO (snd $1, fst $3, snd $3))}
-  |		LPAREN global_dec RPAREN LPAREN parameters RPAREN
+  |  LPAREN global_dec RPAREN LPAREN parameters RPAREN
     {(fst $2, set_type (PROTO (NO_TYPE, fst $5, snd $5)) (snd $2))}
-  |		global_dec LPAREN old_parameters RPAREN
+  |  global_dec LPAREN old_parameters RPAREN
     {(fst $1, OLD_PROTO (snd $1, fst $3, snd $3))}
-  |		LPAREN global_dec RPAREN LPAREN old_parameters RPAREN
+  |  LPAREN global_dec RPAREN LPAREN old_parameters RPAREN
     {(fst $2, set_type (OLD_PROTO (NO_TYPE, fst $5, snd $5)) (snd $2))}
 ;
 global_proto:
@@ -309,7 +308,7 @@ global_dec opt_gcc_attributes
     {match (snd $1) with
        PROTO _
      | OLD_PROTO _ ->
-	(fst $1, snd $1, $2, NOTHING)
+ (fst $1, snd $1, $2, NOTHING)
      | _ -> parse_error $symbolstartofs $endofs }
 ;
 old_proto:
@@ -323,18 +322,18 @@ global_dec opt_gcc_attributes
 
 /*** Old Parameter Style ***/
 old_parameters:
-old_pardecs						{(List.rev $1, false)}
-  |		old_pardecs ELLIPSIS			{(List.rev $1, true)}
+old_pardecs      {(List.rev $1, false)}
+  |  old_pardecs ELLIPSIS   {(List.rev $1, true)}
 ;
 old_pardecs:
-IDENT							{[$1]}
-  |		old_pardecs COMMA IDENT			{$3::$1}
-  |		old_pardecs COMMA NAMED_TYPE	{$3::$1}
+IDENT       {[$1]}
+  |  old_pardecs COMMA IDENT   {$3::$1}
+  |  old_pardecs COMMA NAMED_TYPE {$3::$1}
 ;
 
 old_pardefs:
-old_pardef						{[$1]}
-  |		old_pardefs old_pardef			{$2::$1}
+old_pardef      {[$1]}
+  |  old_pardefs old_pardef   {$2::$1}
 ;
 old_pardef:
 old_type old_defs SEMICOLON
@@ -343,25 +342,25 @@ old_type old_defs SEMICOLON
 old_type:
 old_mods_opt NAMED_TYPE old_mods_opt
     {apply_mods $3 (apply_mods $1 (NAMED_TYPE $2, NO_STORAGE))}
-  |		old_mods_opt comp_type old_mods_opt
+  |  old_mods_opt comp_type old_mods_opt
     {apply_mods $3 (apply_mods $1 ($2, NO_STORAGE))}
-  |		old_mods_opt old_qual
+  |  old_mods_opt old_qual
     {apply_mods (snd $2) (apply_mods $1 ((fst $2), NO_STORAGE))}
 ;
 old_mods_opt:
-/* empty */						{[]}
-  |		CONST							{[BASE_CONST]}
-  |		REGISTER						{[BASE_STORAGE REGISTER]}
+/* empty */      {[]}
+  |  CONST       {[BASE_CONST]}
+  |  REGISTER      {[BASE_STORAGE REGISTER]}
 ;
 old_qual:
-qual_type						{$1}
-  |		old_qual qual_type				{apply_qual $1 $2}
-  |		old_qual CONST					{(fst $1, BASE_CONST::(snd $1))}
-  |		old_qual REGISTER				{(fst $1, (BASE_STORAGE REGISTER)::(snd $1))}
+qual_type      {$1}
+  |  old_qual qual_type    {apply_qual $1 $2}
+  |  old_qual CONST     {(fst $1, BASE_CONST::(snd $1))}
+  |  old_qual REGISTER    {(fst $1, (BASE_STORAGE REGISTER)::(snd $1))}
 ;
 old_defs:
-old_def							{[$1]}
-  |		old_defs COMMA old_def			{$3::$1}
+old_def       {[$1]}
+  |  old_defs COMMA old_def   {$3::$1}
 ;
 old_def:
 old_dec
@@ -370,21 +369,21 @@ old_dec
 old_dec:
 IDENT
     {($1, NO_TYPE)}
-  |		STAR old_dec
+  |  STAR old_dec
     {(fst $2, set_type (PTR NO_TYPE) (snd $2))}
-  |		STAR CONST old_dec
+  |  STAR CONST old_dec
     {(fst $3, set_type (CONST (PTR NO_TYPE)) (snd $3))}
-  |		STAR VOLATILE old_dec
+  |  STAR VOLATILE old_dec
     {(fst $3, set_type (VOLATILE (PTR NO_TYPE)) (snd $3))}
-  |		old_dec LBRACKET comma_expression RBRACKET
+  |  old_dec LBRACKET comma_expression RBRACKET
     {(fst $1, set_type (ARRAY (NO_TYPE, smooth_expression $3)) (snd $1))}
-  |		old_dec LBRACKET RBRACKET
+  |  old_dec LBRACKET RBRACKET
     {(fst $1, set_type (ARRAY (NO_TYPE, NOTHING)) (snd $1))}
-  |		old_dec LPAREN parameters RPAREN
+  |  old_dec LPAREN parameters RPAREN
     {(fst $1, PROTO (snd $1, fst $3, snd $3))}
-  |		LPAREN old_dec RPAREN LPAREN parameters RPAREN
+  |  LPAREN old_dec RPAREN LPAREN parameters RPAREN
     {(fst $2, set_type (PROTO (NO_TYPE, fst $5, snd $5)) (snd $2))}
-  |		LPAREN old_dec RPAREN
+  |  LPAREN old_dec RPAREN
     {$2}
 ;
 
@@ -397,67 +396,67 @@ local_type local_defs SEMICOLON
 local_type:
 local_mod_list_opt local_qual
     {apply_mods (snd $2) (apply_mods $1 ((fst $2), NO_STORAGE))}
-  |		local_mod_list_opt comp_type local_mod_list_opt
+  |  local_mod_list_opt comp_type local_mod_list_opt
     {apply_mods $3 (apply_mods $1 ($2, NO_STORAGE))}
-  |		local_mod_list_opt NAMED_TYPE local_mod_list_opt
+  |  local_mod_list_opt NAMED_TYPE local_mod_list_opt
     {apply_mods $3 (apply_mods $1 (NAMED_TYPE $2, NO_STORAGE))}
 ;
 local_mod_list_opt:
-/* empty */						{[]}
-  |		local_mod_list					{List.rev $1}
+/* empty */      {[]}
+  |  local_mod_list     {List.rev $1}
 ;
 local_mod_list:
-local_mod						{[$1]}
-  |		local_mod_list local_mod		{$2::$1}
+local_mod      {[$1]}
+  |  local_mod_list local_mod  {$2::$1}
 ;
 local_mod:
-STATIC							{ BASE_STORAGE STATIC }
-  |		AUTO							{ BASE_STORAGE AUTO }
-  |		CONST							{ BASE_CONST }
-  |		VOLATILE						{ BASE_VOLATILE }
-  |		REGISTER						{ BASE_STORAGE REGISTER }
-  |		EXTERN							{ BASE_STORAGE EXTERN }
-  |		gcc_attribute					{ BASE_GNU_ATTR $1 }
+STATIC       { BASE_STORAGE STATIC }
+  |  AUTO       { BASE_STORAGE AUTO }
+  |  CONST       { BASE_CONST }
+  |  VOLATILE      { BASE_VOLATILE }
+  |  REGISTER      { BASE_STORAGE REGISTER }
+  |  EXTERN       { BASE_STORAGE EXTERN }
+  |  gcc_attribute     { BASE_GNU_ATTR $1 }
 ;
 local_qual:
-qual_type						{$1}
-  |		local_qual qual_type			{apply_qual $1 $2}
-  |		local_qual local_mod			{(fst $1, $2::(snd $1))}
+qual_type      {$1}
+  |  local_qual qual_type   {apply_qual $1 $2}
+  |  local_qual local_mod   {(fst $1, $2::(snd $1))}
 ;
 local_defs:
-local_def						{[$1]}
-  |		local_defs COMMA local_def		{$3::$1}
+local_def      {[$1]}
+  |  local_defs COMMA local_def  {$3::$1}
 ;
 local_def:
 local_dec opt_gcc_attributes
     {(fst $1, snd $1, $2, NOTHING)}
-  |		local_dec opt_gcc_attributes EQ init_expression
+  |  local_dec opt_gcc_attributes EQ init_expression
     {(fst $1, snd $1, $2, $4)}
 ;
 local_dec:
 IDENT
     {($1, NO_TYPE)}
-  |		NAMED_TYPE
+  |  NAMED_TYPE
     {Clexer.add_identifier $1;($1, NO_TYPE)}
-  |		STAR local_dec
+  |  STAR local_dec
     {(fst $2, set_type (PTR NO_TYPE) (snd $2))}
-  |		STAR RESTRICT local_dec
+  |  STAR RESTRICT local_dec
     {(fst $3, set_type (RESTRICT_PTR NO_TYPE) (snd $3))}
-  |		STAR CONST local_dec
+  |  STAR CONST local_dec
     {(fst $3, set_type (CONST (PTR NO_TYPE)) (snd $3))}
-  |		STAR VOLATILE local_dec
+  |  STAR VOLATILE local_dec
     {(fst $3, set_type (VOLATILE (PTR NO_TYPE)) (snd $3))}
-  |		STAR gcc_attributes local_dec
+  |  STAR gcc_attributes local_dec
     {(fst $3, set_type (GNU_TYPE ($2, PTR NO_TYPE)) (snd $3))}
-  |		local_dec LBRACKET comma_expression RBRACKET
+  |  local_dec LBRACKET comma_expression RBRACKET
     {(fst $1, set_type (ARRAY (NO_TYPE, smooth_expression $3)) (snd $1))}
-  |		local_dec LBRACKET RBRACKET
+  |  local_dec LBRACKET RBRACKET
     {(fst $1, set_type (ARRAY (NO_TYPE, NOTHING)) (snd $1))}
-  |		local_dec LPAREN parameters RPAREN
+  |  local_dec LPAREN parameters RPAREN
     {(fst $1, PROTO (snd $1, fst $3, snd $3))}
-  |		LPAREN local_dec RPAREN LPAREN parameters RPAREN
+  |  LPAREN local_dec RPAREN LPAREN parameters RPAREN
     {(fst $2, set_type (PROTO (NO_TYPE, fst $5, snd $5)) (snd $2))}
-  |		LPAREN local_dec RPAREN
+  |  LPAREN local_dec RPAREN
     {$2}
 ;
 
@@ -466,33 +465,33 @@ IDENT
 typedef_type:
 typedef_sub
     {apply_mods (snd $1) ((fst $1), NO_STORAGE)}
-  |		CONST typedef_sub
+  |  CONST typedef_sub
     {apply_mods (BASE_CONST::(snd $2)) ((fst $2), NO_STORAGE)}
-  |		VOLATILE typedef_sub
+  |  VOLATILE typedef_sub
     {apply_mods (BASE_VOLATILE::(snd $2)) ((fst $2), NO_STORAGE)}
 ;
 typedef_sub:
-NAMED_TYPE						{(NAMED_TYPE $1, [])}
-  |		comp_type						{($1, [])}
-  |		typedef_qual					{$1}
+NAMED_TYPE      {(NAMED_TYPE $1, [])}
+  |  comp_type      {($1, [])}
+  |  typedef_qual     {$1}
 /* !!TODO!! Unknown named type support: add option for it */
-  |		IDENT							{ Clexer.add_type $1; (NAMED_TYPE $1, [])}
-  |		NAMED_TYPE CONST				{(NAMED_TYPE $1, [BASE_CONST])}
-  |		NAMED_TYPE VOLATILE				{(NAMED_TYPE $1, [BASE_VOLATILE])}
-  |		comp_type CONST					{($1, [BASE_CONST])}
-  |		comp_type VOLATILE				{($1, [BASE_VOLATILE])}
-  |		IDENT CONST						{ Clexer.add_type $1; (NAMED_TYPE $1, [BASE_CONST])}
-  |		IDENT VOLATILE					{ Clexer.add_type $1; (NAMED_TYPE $1, [BASE_VOLATILE])}
+  |  IDENT       { Clexer.add_type $1; (NAMED_TYPE $1, [])}
+  |  NAMED_TYPE CONST    {(NAMED_TYPE $1, [BASE_CONST])}
+  |  NAMED_TYPE VOLATILE    {(NAMED_TYPE $1, [BASE_VOLATILE])}
+  |  comp_type CONST     {($1, [BASE_CONST])}
+  |  comp_type VOLATILE    {($1, [BASE_VOLATILE])}
+  |  IDENT CONST      { Clexer.add_type $1; (NAMED_TYPE $1, [BASE_CONST])}
+  |  IDENT VOLATILE     { Clexer.add_type $1; (NAMED_TYPE $1, [BASE_VOLATILE])}
 ;
 typedef_qual:
-qual_type						{$1}
-  |		typedef_qual qual_type			{apply_qual $1 $2}
-  |		typedef_qual CONST				{(fst $1, BASE_CONST::(snd $1))}
-  |		typedef_qual VOLATILE			{(fst $1, BASE_VOLATILE::(snd $1))}
+qual_type      {$1}
+  |  typedef_qual qual_type   {apply_qual $1 $2}
+  |  typedef_qual CONST    {(fst $1, BASE_CONST::(snd $1))}
+  |  typedef_qual VOLATILE   {(fst $1, BASE_VOLATILE::(snd $1))}
 ;
 typedef_defs:
-typedef_def						{[$1]}
-  |		typedef_defs COMMA typedef_def	{$3::$1}
+typedef_def      {[$1]}
+  |  typedef_defs COMMA typedef_def {$3::$1}
 ;
 typedef_def:
 typedef_dec opt_gcc_attributes
@@ -501,111 +500,111 @@ typedef_dec opt_gcc_attributes
 typedef_dec:
   | IDENT | NAMED_TYPE
     {($1, NO_TYPE)}
-  |		STAR typedef_dec
+  |  STAR typedef_dec
     {(fst $2, set_type (PTR NO_TYPE) (snd $2))}
-  |		STAR RESTRICT typedef_dec
+  |  STAR RESTRICT typedef_dec
     {(fst $3, set_type (RESTRICT_PTR NO_TYPE) (snd $3))}
-  |		STAR CONST typedef_dec
+  |  STAR CONST typedef_dec
     {(fst $3, set_type (CONST (PTR NO_TYPE)) (snd $3))}
-  |		STAR VOLATILE typedef_dec
+  |  STAR VOLATILE typedef_dec
     {(fst $3, set_type (VOLATILE (PTR NO_TYPE)) (snd $3))}
-  |		STAR gcc_attributes typedef_dec
+  |  STAR gcc_attributes typedef_dec
     {(fst $3, set_type (GNU_TYPE ($2, PTR NO_TYPE)) (snd $3))}
-  |		typedef_dec LBRACKET comma_expression RBRACKET
+  |  typedef_dec LBRACKET comma_expression RBRACKET
     {(fst $1, set_type (ARRAY (NO_TYPE, smooth_expression $3)) (snd $1))}
-  |		typedef_dec LBRACKET RBRACKET
+  |  typedef_dec LBRACKET RBRACKET
     {(fst $1, set_type (ARRAY (NO_TYPE, NOTHING)) (snd $1))}
-  |		typedef_dec LPAREN parameters RPAREN
+  |  typedef_dec LPAREN parameters RPAREN
     {(fst $1, PROTO (snd $1, fst $3, snd $3))}
-  |		LPAREN typedef_dec RPAREN LPAREN parameters RPAREN
+  |  LPAREN typedef_dec RPAREN LPAREN parameters RPAREN
     {(fst $2, set_type (PROTO (NO_TYPE, fst $5, snd $5)) (snd $2))}
-  |		LPAREN typedef_dec RPAREN
+  |  LPAREN typedef_dec RPAREN
     {$2}
 ;
 
 
 /*** Field Definition ***/
 field_list:
-field_list field				{$2::$1}
-  |		field							{[$1]}
+field_list field    {$2::$1}
+  |  field       {[$1]}
 ;
 field:
-field_type field_defs SEMICOLON	{set_name_group $1 (List.rev $2)}
+field_type field_defs SEMICOLON {set_name_group $1 (List.rev $2)}
 ;
 field_type:
 field_mod_list_opt field_qual
     {apply_mods (snd $2) (apply_mods $1 ((fst $2), NO_STORAGE))}
-  |	field_mod_list_opt comp_type field_mod_list_opt
+  | field_mod_list_opt comp_type field_mod_list_opt
     {apply_mods $3 (apply_mods $1 ($2, NO_STORAGE))}
-  |	field_mod_list_opt	NAMED_TYPE field_mod_list_opt
+  | field_mod_list_opt NAMED_TYPE field_mod_list_opt
     {apply_mods $3 (apply_mods $1 (NAMED_TYPE $2, NO_STORAGE))}
 ;
 field_mod_list_opt:
-/* empty */						{[]}
-  |		field_mod_list					{List.rev $1}
+/* empty */      {[]}
+  |  field_mod_list     {List.rev $1}
 ;
 field_mod_list:
-field_mod						{[$1]}
-  |		field_mod_list field_mod		{$2::$1}
+field_mod      {[$1]}
+  |  field_mod_list field_mod  {$2::$1}
 ;
 field_mod:
-CONST							{BASE_CONST}
-  |		VOLATILE						{BASE_VOLATILE}
-  |		gcc_attribute					{ BASE_GNU_ATTR $1 }
+CONST       {BASE_CONST}
+  |  VOLATILE      {BASE_VOLATILE}
+  |  gcc_attribute     { BASE_GNU_ATTR $1 }
 ;
 field_qual:
-qual_type						{$1}
-  |		field_qual qual_type			{apply_qual $1 $2}
-  |		field_qual field_mod			{(fst $1, $2::(snd $1))}
+qual_type      {$1}
+  |  field_qual qual_type   {apply_qual $1 $2}
+  |  field_qual field_mod   {(fst $1, $2::(snd $1))}
 ;
 field_defs:
-field_defs COMMA field_def		{$3::$1}
-  |		field_def						{[$1]}
+field_defs COMMA field_def  {$3::$1}
+  |  field_def      {[$1]}
 ;
 field_def:
-field_dec						{(fst $1, snd $1, [], NOTHING)}
+field_dec      {(fst $1, snd $1, [], NOTHING)}
 ;
 field_dec:
 /* emtpy */
     {("", NO_TYPE)}
-  |		IDENT
+  |  IDENT
     {($1, NO_TYPE)}
-  |		NAMED_TYPE
+  |  NAMED_TYPE
     {($1, NO_TYPE)}
-  |		STAR field_dec
+  |  STAR field_dec
     {(fst $2, set_type (PTR NO_TYPE) (snd $2))}
-  |		STAR RESTRICT field_dec
+  |  STAR RESTRICT field_dec
     {(fst $3, set_type (RESTRICT_PTR NO_TYPE) (snd $3))}
-  |		STAR CONST field_dec
+  |  STAR CONST field_dec
     {(fst $3, set_type (CONST (PTR NO_TYPE)) (snd $3))}
-  |		STAR VOLATILE field_dec
+  |  STAR VOLATILE field_dec
     {(fst $3, set_type (VOLATILE (PTR NO_TYPE)) (snd $3))}
-  |		STAR gcc_attributes field_dec
+  |  STAR gcc_attributes field_dec
     {(fst $3, set_type (GNU_TYPE ($2, PTR NO_TYPE)) (snd $3))}
-  |		field_dec LBRACKET comma_expression RBRACKET
+  |  field_dec LBRACKET comma_expression RBRACKET
     {(fst $1, set_type (ARRAY (NO_TYPE, smooth_expression $3)) (snd $1))}
-  |		field_dec LBRACKET RBRACKET
+  |  field_dec LBRACKET RBRACKET
     {(fst $1, set_type (ARRAY (NO_TYPE, NOTHING)) (snd $1))}
-  |		field_dec LPAREN parameters RPAREN
+  |  field_dec LPAREN parameters RPAREN
     {(fst $1, PROTO (snd $1, fst $3, snd $3))}
-  |		LPAREN field_dec RPAREN LPAREN parameters RPAREN
+  |  LPAREN field_dec RPAREN LPAREN parameters RPAREN
     {(fst $2, set_type (PROTO (NO_TYPE, fst $5, snd $5)) (snd $2))}
-  |		LPAREN field_dec RPAREN
+  |  LPAREN field_dec RPAREN
     {$2}
-  |		IDENT COLON expression
+  |  IDENT COLON expression
     {($1, BITFIELD (NO_SIGN, $3))}
 ;
 
 
 /*** Parameter Definition ***/
 parameters:
-/* empty */						{([], false)}
-  |		param_list						{(List.rev $1, false)}
-  |		param_list COMMA ELLIPSIS		{(List.rev $1, true)}
+/* empty */      {([], false)}
+  |  param_list      {(List.rev $1, false)}
+  |  param_list COMMA ELLIPSIS  {(List.rev $1, true)}
 ;
 param_list:
-param_list COMMA param			{$3::$1}
-  |		param							{[$1]}
+param_list COMMA param   {$3::$1}
+  |  param       {[$1]}
 ;
 param:
 param_type param_def
@@ -614,32 +613,32 @@ param_type param_def
 param_type:
 param_mods_opt NAMED_TYPE param_mods_opt
     {apply_mods $3 (apply_mods $1 (NAMED_TYPE $2, NO_STORAGE))}
-  |		param_mods_opt comp_type param_mods_opt
+  |  param_mods_opt comp_type param_mods_opt
     {apply_mods $3 (apply_mods $1 ($2, NO_STORAGE))}
-  |		param_mods_opt param_qual
+  |  param_mods_opt param_qual
     {apply_mods (snd $2) (apply_mods $1 ((fst $2), NO_STORAGE))}
 ;
 param_mods_opt:
-/* empty */						{[]}
-  |		param_mods						{List.rev $1}
+/* empty */      {[]}
+  |  param_mods      {List.rev $1}
 ;
 param_mods:
-param_mod						{[$1]}
-  |		param_mods param_mod			{$2::$1}
+param_mod      {[$1]}
+  |  param_mods param_mod   {$2::$1}
 ;
 param_mod:
-CONST							{BASE_CONST}
-  |		REGISTER						{BASE_STORAGE REGISTER}
-  |		VOLATILE						{BASE_VOLATILE}
-  |		gcc_attribute					{ BASE_GNU_ATTR $1 }
+CONST       {BASE_CONST}
+  |  REGISTER      {BASE_STORAGE REGISTER}
+  |  VOLATILE      {BASE_VOLATILE}
+  |  gcc_attribute     { BASE_GNU_ATTR $1 }
 ;
 param_qual:
-qual_type						{$1}
-  |		param_qual qual_type			{apply_qual $1 $2}
-  |		param_qual CONST				{(fst $1, BASE_CONST::(snd $1))}
-  |		param_qual REGISTER				{(fst $1, (BASE_STORAGE REGISTER)::(snd $1))}
-  |		param_qual VOLATILE				{(fst $1, BASE_VOLATILE::(snd $1))}
-  |		param_qual gcc_attribute		{(fst $1, (BASE_GNU_ATTR $2)::(snd $1))}
+qual_type      {$1}
+  |  param_qual qual_type   {apply_qual $1 $2}
+  |  param_qual CONST    {(fst $1, BASE_CONST::(snd $1))}
+  |  param_qual REGISTER    {(fst $1, (BASE_STORAGE REGISTER)::(snd $1))}
+  |  param_qual VOLATILE    {(fst $1, BASE_VOLATILE::(snd $1))}
+  |  param_qual gcc_attribute  {(fst $1, (BASE_GNU_ATTR $2)::(snd $1))}
 ;
 param_def:
 param_dec
@@ -648,27 +647,27 @@ param_dec
 param_dec:
 /* empty */
     { ("", NO_TYPE) }
-  |		IDENT
+  |  IDENT
     { ($1, NO_TYPE) }
-  |		NAMED_TYPE
+  |  NAMED_TYPE
     { ($1, NO_TYPE) }
-  |		STAR param_dec
+  |  STAR param_dec
     {(fst $2, set_type (PTR NO_TYPE) (snd $2))}
-  |		STAR RESTRICT param_dec
+  |  STAR RESTRICT param_dec
     {(fst $3, set_type (RESTRICT_PTR NO_TYPE) (snd $3))}
-  |		STAR CONST param_dec
+  |  STAR CONST param_dec
     {(fst $3, set_type (CONST (PTR NO_TYPE)) (snd $3))}
-  |		STAR VOLATILE param_dec
+  |  STAR VOLATILE param_dec
     {(fst $3, set_type (VOLATILE (PTR NO_TYPE)) (snd $3))}
-  |		STAR gcc_attributes param_dec
+  |  STAR gcc_attributes param_dec
     {(fst $3, set_type (GNU_TYPE ($2, PTR NO_TYPE)) (snd $3))}
-  |		param_dec LBRACKET comma_expression RBRACKET
+  |  param_dec LBRACKET comma_expression RBRACKET
     {(fst $1, set_type (ARRAY (NO_TYPE, smooth_expression $3)) (snd $1))}
-  |		param_dec LBRACKET RBRACKET
+  |  param_dec LBRACKET RBRACKET
     {(fst $1, set_type (ARRAY (NO_TYPE, NOTHING)) (snd $1))}
-  |		LPAREN param_dec RPAREN LPAREN parameters RPAREN
+  |  LPAREN param_dec RPAREN LPAREN parameters RPAREN
     {(fst $2, set_type (PROTO (NO_TYPE, fst $5, snd $5)) (snd $2))}
-  |		LPAREN param_dec RPAREN
+  |  LPAREN param_dec RPAREN
     {$2}
 ;
 
@@ -681,99 +680,99 @@ only_type_type only_def
 only_type_type:
 only_mod_list_opt only_qual
     {apply_mods (snd $2) (apply_mods $1 ((fst $2), NO_STORAGE))}
-  |	only_mod_list_opt comp_type only_mod_list_opt
+  | only_mod_list_opt comp_type only_mod_list_opt
     {apply_mods $3 (apply_mods $1 ($2, NO_STORAGE))}
-  |		only_mod_list_opt NAMED_TYPE only_mod_list_opt
+  |  only_mod_list_opt NAMED_TYPE only_mod_list_opt
     {apply_mods $3 (apply_mods $1 (NAMED_TYPE $2, NO_STORAGE))}
 ;
 only_mod_list_opt:
-/* empty */						{[]}
-  |		only_mod_list					{List.rev $1}
+/* empty */      {[]}
+  |  only_mod_list     {List.rev $1}
 ;
 only_qual:
-qual_type						{$1}
-  |		only_qual qual_type				{apply_qual $1 $2}
-  |		only_qual only_mod				{(fst $1, $2::(snd $1))}
+qual_type      {$1}
+  |  only_qual qual_type    {apply_qual $1 $2}
+  |  only_qual only_mod    {(fst $1, $2::(snd $1))}
 ;
 only_mod_list:
-only_mod						{[$1]}
-  |		only_mod_list only_mod		{$2::$1}
+only_mod      {[$1]}
+  |  only_mod_list only_mod  {$2::$1}
 ;
 only_mod:
-CONST							{BASE_CONST}
-  |		VOLATILE						{BASE_VOLATILE}
-  |		gcc_attribute					{ BASE_GNU_ATTR $1 }
+CONST       {BASE_CONST}
+  |  VOLATILE      {BASE_VOLATILE}
+  |  gcc_attribute     { BASE_GNU_ATTR $1 }
 ;
 only_def:
-only_dec						{$1}
+only_dec      {$1}
 ;
 only_dec:
 /* empty */
     {NO_TYPE}
-  |		STAR only_dec
+  |  STAR only_dec
     {set_type (PTR NO_TYPE) $2}
-  |		STAR RESTRICT only_dec
+  |  STAR RESTRICT only_dec
     {set_type (RESTRICT_PTR NO_TYPE) $3}
-  |		STAR CONST only_dec
+  |  STAR CONST only_dec
     {set_type (CONST (PTR NO_TYPE)) $3}
-  |		STAR VOLATILE only_dec
+  |  STAR VOLATILE only_dec
     {set_type (VOLATILE (PTR NO_TYPE)) $3}
-  |		STAR gcc_attributes only_dec
+  |  STAR gcc_attributes only_dec
     {set_type (GNU_TYPE ($2, PTR NO_TYPE)) $3}
-  |		only_dec LBRACKET comma_expression RBRACKET
+  |  only_dec LBRACKET comma_expression RBRACKET
     {set_type (ARRAY (NO_TYPE, smooth_expression $3)) $1}
-  |		only_dec LBRACKET RBRACKET
+  |  only_dec LBRACKET RBRACKET
     {set_type (ARRAY (NO_TYPE, NOTHING)) $1}
-  |		LPAREN only_dec RPAREN LPAREN parameters RPAREN
+  |  LPAREN only_dec RPAREN LPAREN parameters RPAREN
     {set_type (PROTO (NO_TYPE, fst $5, snd $5)) $2}
-  |		LPAREN only_dec RPAREN
+  |  LPAREN only_dec RPAREN
     {$2}
 ;
 
 
 /*** Base type ***/
 qual_type:
-VOID							{(VOID, [])}
-  |		CHAR							{(CHAR NO_SIGN, [])}
-  |		INT								{(INT (NO_SIZE, NO_SIGN), [])}
-  |		FLOAT							{(FLOAT false, [])}
-  |		DOUBLE							{(DOUBLE false, [])}
-  |		LONG							{(NO_TYPE, [BASE_SIZE LONG])}
-  |		SHORT							{(NO_TYPE, [BASE_SIZE SHORT])}
-  |		SIGNED							{(NO_TYPE, [BASE_SIGN SIGNED])}
-  |		UNSIGNED						{(NO_TYPE, [BASE_SIGN UNSIGNED])}
+VOID       {(VOID, [])}
+  |  CHAR       {(CHAR NO_SIGN, [])}
+  |  INT        {(INT (NO_SIZE, NO_SIGN), [])}
+  |  FLOAT       {(FLOAT false, [])}
+  |  DOUBLE       {(DOUBLE false, [])}
+  |  LONG       {(NO_TYPE, [BASE_SIZE LONG])}
+  |  SHORT       {(NO_TYPE, [BASE_SIZE SHORT])}
+  |  SIGNED       {(NO_TYPE, [BASE_SIGN SIGNED])}
+  |  UNSIGNED      {(NO_TYPE, [BASE_SIGN UNSIGNED])}
 ;
 comp_type:
 STRUCT type_name
     {STRUCT ($2, [])}
-  |		STRUCT LBRACE field_list RBRACE
+  |  STRUCT LBRACE field_list RBRACE
     {STRUCT ("", List.rev $3)}
-  |		STRUCT type_name LBRACE field_list RBRACE
+  |  STRUCT type_name LBRACE field_list RBRACE
     {STRUCT ($2, List.rev $4)}
-  |		UNION type_name
+  |  UNION type_name
     {UNION ($2, [])}
-  |		UNION LBRACE field_list RBRACE
+  |  UNION LBRACE field_list RBRACE
     {UNION ("", List.rev $3)}
-  |		UNION type_name LBRACE field_list RBRACE
+  |  UNION type_name LBRACE field_list RBRACE
     {UNION ($2, List.rev $4)}
-  |		ENUM type_name
+  |  ENUM type_name
     {ENUM ($2, [])}
-  |		ENUM LBRACE enum_list RBRACE
+  |  ENUM LBRACE enum_list RBRACE
     {ENUM ("", List.rev $3)}
-  |		ENUM LBRACE enum_list COMMA RBRACE
+  |  ENUM LBRACE enum_list COMMA RBRACE
     {ENUM ("", List.rev $3)}
-  |		ENUM type_name LBRACE enum_list RBRACE
+  |  ENUM type_name LBRACE enum_list RBRACE
     {ENUM ($2, List.rev $4)}
 ;
 type_name:
-IDENT							{$1}
-  |		NAMED_TYPE						{$1}
+IDENT       {$1}
+  |  NAMED_TYPE      {$1}
 ;
-enum_list:	enum_name					{[$1]}
-  |		enum_list COMMA enum_name	{$3::$1}
+enum_list: enum_name     {[$1]}
+  |  enum_list COMMA enum_name {$3::$1}
 ;
-enum_name:	IDENT						{($1, NOTHING)}
-  |			IDENT EQ expression			{($1, $3)}
+enum_name: IDENT      {($1, NOTHING)}
+  |   IDENT EQ expression   {($1, $3)}
 ;
 
 
@@ -781,214 +780,214 @@ enum_name:	IDENT						{($1, NOTHING)}
 init_expression:
 LBRACE init_comma_expression RBRACE
     {CONSTANT (CONST_COMPOUND (List.rev $2))}
-  |		expression
+  |  expression
     {$1}
 ;
 init_comma_expression:
 init_expression
     {[$1]}
-  |		init_comma_expression COMMA init_expression
+  |  init_comma_expression COMMA init_expression
     {$3::$1}
-  |		init_comma_expression COMMA
+  |  init_comma_expression COMMA
     {$1}
 ;
 opt_expression:
 /* empty */
     {NOTHING}
-  |		comma_expression
+  |  comma_expression
     {smooth_expression $1}
 ;
 comma_expression:
 expression
     {[$1]}
-  |		comma_expression COMMA expression
+  |  comma_expression COMMA expression
     {$3::$1}
 ;
 expression:
 constant
     {CONSTANT $1}
-  |		IDENT
+  |  IDENT
     {VARIABLE $1}
-  |		SIZEOF expression
+  |  SIZEOF expression
     {EXPR_SIZEOF $2}
-  |	 	SIZEOF LPAREN only_type RPAREN
+  |   SIZEOF LPAREN only_type RPAREN
     {TYPE_SIZEOF $3}
-  |		PLUS expression
+  |  PLUS expression
     {UNARY (PLUS, $2)}
-  |		MINUS expression
+  |  MINUS expression
     {UNARY (MINUS, $2)}
-  |		STAR expression
+  |  STAR expression
     {UNARY (MEMOF, $2)}
-  |		AND expression				%prec ADDROF
+  |  AND expression    %prec ADDROF
     {UNARY (ADDROF, $2)}
-  |		EXCLAM expression
+  |  EXCLAM expression
     {UNARY (NOT, $2)}
-  |		TILDE expression
+  |  TILDE expression
     {UNARY (BNOT, $2)}
-  |		PLUS_PLUS expression %prec CAST
+  |  PLUS_PLUS expression %prec CAST
     {UNARY (PREINCR, $2)}
-  |		expression PLUS_PLUS
+  |  expression PLUS_PLUS
     {UNARY (POSINCR, $1)}
-  |		MINUS_MINUS expression %prec CAST
+  |  MINUS_MINUS expression %prec CAST
     {UNARY (PREDECR, $2)}
-  |		expression MINUS_MINUS
+  |  expression MINUS_MINUS
     {UNARY (POSDECR, $1)}
-  |		expression ARROW IDENT
+  |  expression ARROW IDENT
     {MEMBEROFPTR ($1, $3)}
-  |		expression ARROW NAMED_TYPE
+  |  expression ARROW NAMED_TYPE
     {MEMBEROFPTR ($1, $3)}
-  |		expression DOT IDENT
+  |  expression DOT IDENT
     {MEMBEROF ($1, $3)}
-  |		expression DOT NAMED_TYPE
+  |  expression DOT NAMED_TYPE
     {MEMBEROF ($1, $3)}
-  |		LPAREN body RPAREN
+  |  LPAREN body RPAREN
     {Clexer.test_gcc(); set_eline $1 (GNU_BODY (snd $2))}
-  |		LPAREN comma_expression RPAREN
+  |  LPAREN comma_expression RPAREN
     {set_eline $1 (smooth_expression $2)}
-  |		LPAREN only_type RPAREN expression %prec CAST
+  |  LPAREN only_type RPAREN expression %prec CAST
     {set_eline $1 (CAST ($2, $4))}
-  |		expression LPAREN opt_expression RPAREN
+  |  expression LPAREN opt_expression RPAREN
     {set_eline $2 (CALL ($1, list_expression $3))}
-  |		expression LBRACKET comma_expression RBRACKET
+  |  expression LBRACKET comma_expression RBRACKET
     {INDEX ($1, smooth_expression $3)}
-  |		expression QUEST expression COLON expression
+  |  expression QUEST expression COLON expression
     {QUESTION ($1, $3, $5)}
-  |		expression PLUS expression
+  |  expression PLUS expression
     {BINARY(ADD ,$1 , $3)}
-  |		expression MINUS expression
+  |  expression MINUS expression
     {BINARY(SUB ,$1 , $3)}
-  |		expression STAR expression
+  |  expression STAR expression
     {BINARY(MUL ,$1 , $3)}
-  |		expression SLASH expression
+  |  expression SLASH expression
     {BINARY(DIV ,$1 , $3)}
-  |		expression PERCENT expression
+  |  expression PERCENT expression
     {BINARY(MOD ,$1 , $3)}
-  |		expression AND_AND expression
+  |  expression AND_AND expression
     {BINARY(AND ,$1 , $3)}
-  |		expression PIPE_PIPE expression
+  |  expression PIPE_PIPE expression
     {BINARY(OR ,$1 , $3)}
-  |		expression AND expression
+  |  expression AND expression
     {BINARY(BAND ,$1 , $3)}
-  |		expression PIPE expression
+  |  expression PIPE expression
     {BINARY(BOR ,$1 , $3)}
-  |		expression CIRC expression
+  |  expression CIRC expression
     {BINARY(XOR ,$1 , $3)}
-  |		expression EQ_EQ expression
+  |  expression EQ_EQ expression
     {BINARY(EQ ,$1 , $3)}
-  |		expression EXCLAM_EQ expression
+  |  expression EXCLAM_EQ expression
     {BINARY(NE ,$1 , $3)}
-  |		expression INF expression
+  |  expression INF expression
     {BINARY(LT ,$1 , $3)}
-  |		expression SUP expression
+  |  expression SUP expression
     {BINARY(GT ,$1 , $3)}
-  |		expression INF_EQ expression
+  |  expression INF_EQ expression
     {BINARY(LE ,$1 , $3)}
-  |		expression SUP_EQ expression
+  |  expression SUP_EQ expression
     {BINARY(GE ,$1 , $3)}
-  |		expression  INF_INF expression
+  |  expression  INF_INF expression
     {BINARY(SHL ,$1 , $3)}
-  |		expression  SUP_SUP expression
+  |  expression  SUP_SUP expression
     {BINARY(SHR ,$1 , $3)}
-  |		expression EQ expression
+  |  expression EQ expression
     {set_eline $2 (BINARY(ASSIGN ,$1 , $3))}
-  |		expression PLUS_EQ expression
+  |  expression PLUS_EQ expression
     {set_eline $2 (BINARY(ADD_ASSIGN ,$1 , $3))}
-  |		expression MINUS_EQ expression
+  |  expression MINUS_EQ expression
     {set_eline $2 (BINARY(SUB_ASSIGN ,$1 , $3))}
-  |		expression STAR_EQ expression
+  |  expression STAR_EQ expression
     {set_eline $2 (BINARY(MUL_ASSIGN ,$1 , $3))}
-  |		expression SLASH_EQ expression
+  |  expression SLASH_EQ expression
     {set_eline $2 (BINARY(DIV_ASSIGN ,$1 , $3))}
-  |		expression PERCENT_EQ expression
+  |  expression PERCENT_EQ expression
     {set_eline $2 (BINARY(MOD_ASSIGN ,$1 , $3))}
-  |		expression AND_EQ expression
+  |  expression AND_EQ expression
     {set_eline $2 (BINARY(BAND_ASSIGN ,$1 , $3))}
-  |		expression PIPE_EQ expression
+  |  expression PIPE_EQ expression
     {set_eline $2 (BINARY(BOR_ASSIGN ,$1 , $3))}
-  |		expression CIRC_EQ expression
+  |  expression CIRC_EQ expression
     {set_eline $2 (BINARY(XOR_ASSIGN ,$1 , $3))}
-  |		expression INF_INF_EQ expression
+  |  expression INF_INF_EQ expression
     {set_eline $2 (BINARY(SHL_ASSIGN ,$1 , $3))}
-  |		expression SUP_SUP_EQ expression
+  |  expression SUP_SUP_EQ expression
     {set_eline $2 (BINARY(SHR_ASSIGN ,$1 , $3))}
 ;
 constant:
-CST_INT							{CONST_INT $1}
-  |		CST_FLOAT						{CONST_FLOAT $1}
-  |		CST_CHAR						{CONST_CHAR $1}
-  |		string_list						{CONST_STRING $1}
+CST_INT       {CONST_INT $1}
+  |  CST_FLOAT      {CONST_FLOAT $1}
+  |  CST_CHAR      {CONST_CHAR $1}
+  |  string_list      {CONST_STRING $1}
 ;
 string_list:
-CST_STRING						{$1}
-  |		string_list CST_STRING			{$1 ^ $2}
+CST_STRING      {$1}
+  |  string_list CST_STRING   {$1 ^ $2}
 ;
 
 
 /*** statements ***/
 body_begin:
-LBRACE 							{Clexer.push_context (); $1}
+LBRACE        {Clexer.push_context (); $1}
 ;
 body_middle:
-opt_locals opt_stats 			{($1, $2)}
+opt_locals opt_stats    {($1, $2)}
 ;
 body:
-body_begin body_middle RBRACE 	{Clexer.pop_context(); ($1, $2)}
+body_begin body_middle RBRACE  {Clexer.pop_context(); ($1, $2)}
 ;
 opt_locals:
-/* empty */						{[]}
-  |		locals							{List.rev $1}
+/* empty */      {[]}
+  |  locals       {List.rev $1}
 ;
 locals:
-local							{[$1]}
-  |		locals local					{$2::$1}
+local       {[$1]}
+  |  locals local     {$2::$1}
 ;
 opt_stats:
-/* empty */						{NOP}
-  |		stats							{$1}
+/* empty */      {NOP}
+  |  stats       {$1}
 ;
 stats:
-statement						{$1}
-  |   	stats statement					{SEQUENCE($1, $2)}
+statement      {$1}
+  |    stats statement     {SEQUENCE($1, $2)}
 ;
 statement:
 SEMICOLON
     {set_line $1 NOP}
-  |		comma_expression SEMICOLON
+  |  comma_expression SEMICOLON
     {set_line $2 (COMPUTATION (smooth_expression $1))}
-  |		body
+  |  body
     {set_line (fst $1) (BLOCK (snd $1))}
-  |		IF LPAREN comma_expression RPAREN statement %prec IF
+  |  IF LPAREN comma_expression RPAREN statement %prec IF
     {set_line $1 (IF (smooth_expression $3, $5, NOP))}
-  |		IF LPAREN comma_expression RPAREN statement ELSE statement
+  |  IF LPAREN comma_expression RPAREN statement ELSE statement
     {set_line $1 (IF (smooth_expression $3, $5, set_line $6 $7))}
-  |		SWITCH LPAREN comma_expression RPAREN statement
+  |  SWITCH LPAREN comma_expression RPAREN statement
     {set_line $1 (SWITCH (smooth_expression $3, $5))}
-  |		WHILE LPAREN comma_expression RPAREN statement
+  |  WHILE LPAREN comma_expression RPAREN statement
     {set_line $1 (WHILE (smooth_expression $3, $5))}
-  |		DO statement WHILE LPAREN comma_expression RPAREN SEMICOLON
+  |  DO statement WHILE LPAREN comma_expression RPAREN SEMICOLON
     {set_line $1 (DOWHILE (smooth_expression $5, $2))}
-  |		FOR LPAREN opt_expression SEMICOLON opt_expression
+  |  FOR LPAREN opt_expression SEMICOLON opt_expression
 SEMICOLON opt_expression RPAREN statement
     {set_line $1 (FOR ($3, $5, $7, $9))}
-  |		IDENT COLON statement
+  |  IDENT COLON statement
     {LABEL ($1, $3)}
-  |		CASE expression COLON statement
+  |  CASE expression COLON statement
     {set_line $1 (CASE ($2, $4))}
-  |		DEFAULT COLON statement
+  |  DEFAULT COLON statement
     {set_line $1 (DEFAULT $3)}
-  |		RETURN SEMICOLON
+  |  RETURN SEMICOLON
     {set_line $1 (RETURN NOTHING)}
-  |		RETURN expression SEMICOLON
+  |  RETURN expression SEMICOLON
     {set_line $1 (RETURN $2)}
-  |		BREAK SEMICOLON
+  |  BREAK SEMICOLON
     {set_line $1 BREAK}
-  |		CONTINUE SEMICOLON
+  |  CONTINUE SEMICOLON
     {set_line $1 CONTINUE}
-  |		GOTO IDENT SEMICOLON
+  |  GOTO IDENT SEMICOLON
     {set_line $1 (GOTO $2)}
-  |		ASM LPAREN CST_STRING RPAREN SEMICOLON
+  |  ASM LPAREN CST_STRING RPAREN SEMICOLON
     { ASM $3 }
-  |		ASM LPAREN CST_STRING gnu_asm_io gnu_asm_io opt_gnu_asm_mods RPAREN SEMICOLON
+  |  ASM LPAREN CST_STRING gnu_asm_io gnu_asm_io opt_gnu_asm_mods RPAREN SEMICOLON
     { Clexer.test_gcc(); GNU_ASM ($3, List.rev $4, List.rev $5, List.rev $6) }
 ;
 
@@ -1010,28 +1009,28 @@ COLON gnu_asm_args
 gnu_asm_args:
 gnu_asm_arg
     { [$1] }
-  |	gnu_asm_args COMMA gnu_asm_arg
+  | gnu_asm_args COMMA gnu_asm_arg
     { $3::$1 }
 ;
 
 gnu_asm_arg:
 CST_STRING LPAREN expression RPAREN
     { ("", $1, $3) }
-  |	LBRACKET IDENT RBRACKET CST_STRING LPAREN expression RPAREN
+  | LBRACKET IDENT RBRACKET CST_STRING LPAREN expression RPAREN
     { ($2, $4, $6) }
 ;
 
 opt_gnu_asm_mods:
 /* empty */
     { [] }
-  |	COLON gnu_asm_mods
+  | COLON gnu_asm_mods
     { $2 }
 ;
 
 gnu_asm_mods:
 CST_STRING
     { [$1] }
-  |	gnu_asm_mods COMMA CST_STRING
+  | gnu_asm_mods COMMA CST_STRING
     { $3::$1 }
 ;
 
@@ -1040,56 +1039,56 @@ CST_STRING
 opt_gcc_attributes:
 /* empty */
     { Clexer.test_gcc(); [] }
-  |	gcc_attributes
+  | gcc_attributes
     { Clexer.test_gcc(); List.rev $1 }
 
 gcc_attributes:
 gcc_attribute
     { $1 }
-  |	gcc_attributes gcc_attribute
+  | gcc_attributes gcc_attribute
     { List.append $1 $2 }
 
 gcc_attribute:
 ATTRIBUTE LPAREN LPAREN opt_gnu_args RPAREN RPAREN
     { List.rev $4 }
-/*|	GNU_ATTRS
+/*| GNU_ATTRS
     { $1 }*/
-  |	EXTENSION
+  | EXTENSION
     { [GNU_EXTENSION] }
-  |	INLINE
+  | INLINE
     { [GNU_INLINE] }
 ;
 
 opt_gnu_args:
 /* empty */
     { [] }
-  |	gnu_args
+  | gnu_args
     { $1 }
 ;
 
 gnu_args:
 gnu_arg
     {[$1]}
-  |	gnu_args COMMA gnu_arg
+  | gnu_args COMMA gnu_arg
     {$3::$1}
 ;
 
 gnu_arg:
 gnu_id
     { GNU_ID $1 }
-  |	constant
+  | constant
     { GNU_CST $1 }
-  |	gnu_id LPAREN opt_gnu_args RPAREN
+  | gnu_id LPAREN opt_gnu_args RPAREN
     { GNU_CALL ($1, List.rev $3) }
 ;
 
 gnu_id:
 IDENT
     { $1 }
-  |	GNU_ATTRS
+  | GNU_ATTRS
     {
       match $1 with
-	[(Cabs.GNU_ID name)] -> name
+ [(Cabs.GNU_ID name)] -> name
       | _ -> parse_error $symbolstartofs $endofs
     }
 ;

--- a/frontc/cparser.mly
+++ b/frontc/cparser.mly
@@ -147,7 +147,7 @@ AND_EQ PIPE_EQ CIRC_EQ INF_INF_EQ SUP_SUP_EQ
 %left PLUS MINUS
 %left STAR SLASH PERCENT CONST VOLATILE RESTRICT
 %right EXCLAM TILDE PLUS_PLUS MINUS_MINUS CAST RPAREN ADDROF
-%left  LBRACKET
+%left LBRACKET
 %left DOT ARROW LPAREN SIZEOF
 
 /* Non-terminals informations */
@@ -970,12 +970,9 @@ statement:
 
 /* "Basic asm" https://gcc.gnu.org/onlinedocs/gcc/Basic-Asm.html#Basic-Asm */
 basic_asm:
-ASM opt_gcc_attributes LPAREN string_list RPAREN
-  { ASM $4 }
-| ASM VOLATILE opt_gcc_attributes LPAREN string_list RPAREN
-  { ASM $5 }
-| ASM opt_gcc_attributes VOLATILE LPAREN string_list RPAREN
-  { ASM $5 }
+  | ASM VOLATILE? opt_gcc_attributes LPAREN; asm=string_list; RPAREN
+    { ASM asm }
+;
 
 /*** GNU asm ***/
 gnu_asm_io: COLON gnu_asm_args { $2 };

--- a/frontc/cparser.mly
+++ b/frontc/cparser.mly
@@ -185,10 +185,7 @@ AND_EQ PIPE_EQ CIRC_EQ INF_INF_EQ SUP_SUP_EQ
 
 interpret: file {$1};
 
-file:
-  | EOF   {[]}
-  | globals EOF {$1};
-;
+file: globals {$1};
 
 globals:
   | global* EOF {$1}
@@ -546,7 +543,7 @@ qual_type      {$1}
   |  field_qual field_mod   {(fst $1, $2::(snd $1))}
 ;
 field_defs:
-field_defs COMMA field_def  {$3::$1}
+  | field_defs COMMA field_def  {$3::$1}
   |  field_def      {[$1]}
 ;
 field_def:


### PR DESCRIPTION
Removes 11 shift/reduce conflicts in total:

* Two conflicts were related to excessive EOF tokens.
* One due to volatile keyword in a function prototype before an assembly string
  (solved by inlining)
* Eight conflicts happen because empty strucutres (resolved by moving up)


The grammar was also reindented (still not fully) and cleaned by using more readable syntax available from the Menhir standard library.