### PR TITLE
allows a typedefed named to immediately follow its typedef

### DIFF
--- a/ctoxml/test.t/run.t
+++ b/ctoxml/test.t/run.t
@@ -3875,3 +3875,16 @@
   		</field>
   	</struct>
   </file>
+
+  $ echo 'typedef int T; T bar();' | ctoxml
+  <?xml version="1.0" encoding="iso-8859-1" standalone="yes"?>
+  <file>
+  	<type id="T" store="auto">
+  		<long/>
+  	</type>
+  	<fundec id="bar" store="auto">
+  		<type>
+  			<type ref="T"/>
+  		</type>
+  	</fundec>
+  </file>

--- a/frontc/cparser.mly
+++ b/frontc/cparser.mly
@@ -193,11 +193,12 @@ globals:
 ;
 
 typedef:
-  |  TYPEDEF typedef_type typedef_defs SEMICOLON
-    {let _ = List.iter (fun (id, _, _, _) -> Clexer.add_type id) $3 in
-     TYPEDEF (set_name_group (fst $2, snd $2) $3, [])}
-  |  gcc_attribute TYPEDEF typedef_type typedef_defs SEMICOLON
-    {let _ = List.iter (fun (id, _, _, _) -> Clexer.add_type id) $4 in
+  |  TYPEDEF typedef_type typedef_defs
+    {
+      List.iter (fun (id, _, _, _) -> Clexer.add_type id) $3;
+      TYPEDEF (set_name_group (fst $2, snd $2) $3, [])}
+  |  gcc_attribute TYPEDEF typedef_type typedef_defs
+    {List.iter (fun (id, _, _, _) -> Clexer.add_type id) $4;
      TYPEDEF (set_name_group (fst $3, snd $3) $4, $1)}
 ;
 
@@ -226,7 +227,7 @@ global:
     { OLDFUNDEF (set_single $1 $2, List.rev $3, (snd $4)) }
   |  global_type SEMICOLON
     {ONLYTYPEDEF (set_name_group $1 [])}
-  | typedef {$1}
+  | typedef SEMICOLON {$1}
 ;
 global_type:
   | global_mod_list_opt global_qual
@@ -448,7 +449,7 @@ IDENT
 
 /*** Typedef Definition ***/
 typedef_type:
-typedef_sub
+  | typedef_sub
     {apply_mods (snd $1) ((fst $1), NO_STORAGE)}
   |  CONST typedef_sub
     {apply_mods (BASE_CONST::(snd $2)) ((fst $2), NO_STORAGE)}


### PR DESCRIPTION
In the following example
```
typedef int T; T foo(void);
```

i.e., when the next token after a typedef is the typedefed name, the T
token is already looked ahead, so it is recognized as IDENT not as
NAMED_TYPE, e.g., here is the trace,
```
Lookahead token is now IDENT (15-16) <-- 'T'
Reducing production typedef -> TYPEDEF typedef_type typedef_defs SEMICOLON
adding T <-- debug output from the lexer, indicating that T was added
```

The solution is to factor out the typedef non-terminal and move the
semicolon to globals so that we have it reduced earlier, when the next
token is SEMICOLON:

```
Reducing production typedef -> TYPEDEF typedef_type typedef_defs
adding T <-- typedef reduces before semicolon
State 542:
Shifting (SEMICOLON) to state 543
State 543:
Lookahead token is now NAMED_TYPE (15-16) <-- it is now recognized as type name
```

Fixes #23