### PR TITLE
allows `const volatile` type modifiers

### DIFF
--- a/ctoxml/test.t/run.t
+++ b/ctoxml/test.t/run.t
@@ -3888,3 +3888,15 @@
   		</type>
   	</fundec>
   </file>
+
+  $ echo 'const volatile int n;' | dune exec ctoxml
+  <?xml version="1.0" encoding="iso-8859-1" standalone="yes"?>
+  <file>
+  	<var id="n" store="auto">
+  		<volatile>
+  			<const>
+  				<long/>
+  			</const>
+  		</volatile>
+  	</var>
+  </file>

--- a/frontc/cparser.mly
+++ b/frontc/cparser.mly
@@ -38,7 +38,7 @@
         | _ -> raise BadModifier in
       let check_access typ =
         match typ with
-          PROTO _ | OLD_PROTO _ | CONST _ | VOLATILE _ -> false
+          PROTO _ | OLD_PROTO _ -> false
           | _ -> true in
       match modi with
         BASE_SIGN _ -> (mod_root typ, sto)


### PR DESCRIPTION
they were explicitly disabled but I can find any reasons why

fixes #6 