### PR TITLE
adds more tests

### DIFF
--- a/ctoxml/test.t/anonymous-structs.c
+++ b/ctoxml/test.t/anonymous-structs.c
@@ -1,0 +1,17 @@
+struct Scope {
+    // Anonymous union
+    union {
+        char alpha;
+        int num;
+    };
+};
+
+struct Scope2
+{
+    // Anonymous structure
+    struct
+    {
+        char alpha;
+        int num;
+    };
+};

--- a/ctoxml/test.t/atomic_parenthesis.c
+++ b/ctoxml/test.t/atomic_parenthesis.c
@@ -1,0 +1,2 @@
+// atomic_parenthesis.c
+int _Atomic (x);

--- a/ctoxml/test.t/dangling_else.c
+++ b/ctoxml/test.t/dangling_else.c
@@ -1,0 +1,7 @@
+// dangling_else.c
+int f(void) {
+  if(0)
+    if(1) return 1;
+   else return 0;
+  return 1;
+}

--- a/ctoxml/test.t/echo.c
+++ b/ctoxml/test.t/echo.c
@@ -1,0 +1,58 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+const char *strv[] = {
+    "Now we will print some random stuff.",
+    "Be not afraid of greatness:",
+    "some are born great, some achieve greatness",
+    "and some have greatness thrust upon them",
+    "To thine own self be true, and it must follow",
+    "as the night the day, thou canst not",
+    "then be false to any man",
+    "The course of true love never did run smooth"
+};
+
+void print_endline(const char *msg) {
+    char *p = msg;
+    while (*p) putchar(*p++);
+    putchar('\n');
+}
+
+
+void print_strings(const char **strings) {
+    const char **p;
+    for (p = strings; *p; p++) {
+        print_endline(*p);
+    }
+}
+
+int main(int argc, const char **argv) {
+    int i,j;
+    const int strc = sizeof(strv) / sizeof(*strv);
+    const int size = argc + strc + 1;
+    char *strings[size];
+
+    for (i = 0; i < argc; i++) {
+        strings[i] = strcpy(malloc(strlen(argv[i]) + 1), argv[i]);
+    }
+
+    for (j = 0; j < strc; j++, i++) {
+        char *b = strchr(strv[j], ' ') + 1;
+        char *e = strchr(b, ' ');
+        int size = e-b+1;
+        char *dst = malloc(size);
+        memmove(dst, b, size);
+        dst[size-1] = NULL;
+        strings[i] = dst;
+    }
+
+    strings[size-1] = NULL;
+
+    print_strings(strings);
+
+    for (i = 0; i < size; i++) {
+        free(strings[i]);
+    }
+    return 0;
+}

--- a/ctoxml/test.t/enum.c
+++ b/ctoxml/test.t/enum.c
@@ -1,0 +1,4 @@
+// enum.c
+typedef enum { a, b = a } foo;
+// Each enumeration constant has scope that begins just after the
+// appearance of its defining enumerator in an enumerator list.

--- a/ctoxml/test.t/obj.c
+++ b/ctoxml/test.t/obj.c
@@ -1,0 +1,22 @@
+int sum_internal_1(int a, int b) {
+    return a + b;
+}
+
+int sum_internal_3(int a, int b);
+
+int sum_internal_2(int a, int b) {
+    int c = sum_internal_3(a, 42);
+    return sum_internal_1(a, b) + c;
+}
+
+extern int sum_external(int a, int b);
+
+int sum_internal_3(int a, int b) {
+    if (a > b) {
+        int c = a + b;
+        return sum_internal_1(c, b);
+    } else
+        if (a < b)
+            return sum_external(a, b);
+        else return sum_internal_2(a, b);
+}

--- a/ctoxml/test.t/run.t
+++ b/ctoxml/test.t/run.t
@@ -3900,3 +3900,1434 @@
   		</volatile>
   	</var>
   </file>
+
+  $ ctoxml echo.c
+  <?xml version="1.0" encoding="iso-8859-1" standalone="yes"?>
+  <file>
+  	<var id="strv" store="auto">
+  		<array>
+  			<ptr>
+  				<const>
+  					<char/>
+  				</const>
+  			</ptr>
+  			<size>
+  				<nothing/>
+  			</size>
+  		</array>
+  		<compound>
+  			<string>Now we will print some random stuff.</string>
+  			<string>Be not afraid of greatness:</string>
+  			<string>some are born great, some achieve greatness</string>
+  			<string>and some have greatness thrust upon them</string>
+  			<string>To thine own self be true, and it must follow</string>
+  			<string>as the night the day, thou canst not</string>
+  			<string>then be false to any man</string>
+  			<string>The course of true love never did run smooth</string>
+  		</compound>
+  	</var>
+  	<fundef id="print_endline" store="auto">
+  		<type>
+  			<void/>
+  		</type>
+  		<param name="msg" store="auto">
+  			<ptr>
+  				<const>
+  					<char/>
+  				</const>
+  			</ptr>
+  		</param>
+  		<body>
+  			<var id="p" store="auto">
+  				<ptr>
+  					<char/>
+  				</ptr>
+  				<get ref="msg"/>
+  			</var>
+  			<while>
+  				<memof>
+  					<get ref="p"/>
+  				</memof>
+  				<call>
+  					<get ref="putchar"/>
+  					<memof>
+  						<postinc>
+  							<get ref="p"/>
+  						</postinc>
+  					</memof>
+  				</call>
+  			</while>
+  			<call>
+  				<get ref="putchar"/>
+  				<char>
+  </char>
+  			</call>
+  		</body>
+  	</fundef>
+  	<fundef id="print_strings" store="auto">
+  		<type>
+  			<void/>
+  		</type>
+  		<param name="strings" store="auto">
+  			<ptr>
+  				<ptr>
+  					<const>
+  						<char/>
+  					</const>
+  				</ptr>
+  			</ptr>
+  		</param>
+  		<body>
+  			<for>
+  				<set>
+  					<get ref="p"/>
+  					<get ref="strings"/>
+  				</set>
+  				<memof>
+  					<get ref="p"/>
+  				</memof>
+  				<postinc>
+  					<get ref="p"/>
+  				</postinc>
+  				<block>
+  					<call>
+  						<get ref="print_endline"/>
+  						<memof>
+  							<get ref="p"/>
+  						</memof>
+  					</call>
+  				</block>
+  			</for>
+  		</body>
+  	</fundef>
+  	<fundef id="main" store="auto">
+  		<type>
+  			<long/>
+  		</type>
+  		<param name="argc" store="auto">
+  			<long/>
+  		</param>
+  		<param name="argv" store="auto">
+  			<ptr>
+  				<ptr>
+  					<const>
+  						<char/>
+  					</const>
+  				</ptr>
+  			</ptr>
+  		</param>
+  		<body>
+  			<var id="i" store="auto">
+  				<long/>
+  			</var>
+  			<var id="j" store="auto">
+  				<long/>
+  			</var>
+  			<var id="strc" store="auto">
+  				<const>
+  					<long/>
+  				</const>
+  				<div>
+  					<sizeof>
+  						<get ref="strv"/>
+  					</sizeof>
+  					<sizeof>
+  						<memof>
+  							<get ref="strv"/>
+  						</memof>
+  					</sizeof>
+  				</div>
+  			</var>
+  			<var id="size" store="auto">
+  				<const>
+  					<long/>
+  				</const>
+  				<add>
+  					<add>
+  						<get ref="argc"/>
+  						<get ref="strc"/>
+  					</add>
+  					<int>1</int>
+  				</add>
+  			</var>
+  			<var id="strings" store="auto">
+  				<array>
+  					<ptr>
+  						<char/>
+  					</ptr>
+  					<size>
+  						<get ref="size"/>
+  					</size>
+  				</array>
+  			</var>
+  			<for>
+  				<set>
+  					<get ref="i"/>
+  					<int>0</int>
+  				</set>
+  				<lt>
+  					<get ref="i"/>
+  					<get ref="argc"/>
+  				</lt>
+  				<postinc>
+  					<get ref="i"/>
+  				</postinc>
+  				<block>
+  					<set>
+  						<index>
+  							<get ref="strings"/>
+  							<get ref="i"/>
+  						</index>
+  						<call>
+  							<get ref="strcpy"/>
+  							<call>
+  								<get ref="malloc"/>
+  								<add>
+  									<call>
+  										<get ref="strlen"/>
+  										<index>
+  											<get ref="argv"/>
+  											<get ref="i"/>
+  										</index>
+  									</call>
+  									<int>1</int>
+  								</add>
+  							</call>
+  							<index>
+  								<get ref="argv"/>
+  								<get ref="i"/>
+  							</index>
+  						</call>
+  					</set>
+  				</block>
+  			</for>
+  			<for>
+  				<set>
+  					<get ref="j"/>
+  					<int>0</int>
+  				</set>
+  				<lt>
+  					<get ref="j"/>
+  					<get ref="strc"/>
+  				</lt>
+  				<comma>
+  					<postinc>
+  						<get ref="j"/>
+  					</postinc>
+  					<postinc>
+  						<get ref="i"/>
+  					</postinc>
+  				</comma>
+  				<block>
+  					<var id="b" store="auto">
+  						<ptr>
+  							<char/>
+  						</ptr>
+  						<add>
+  							<call>
+  								<get ref="strchr"/>
+  								<index>
+  									<get ref="strv"/>
+  									<get ref="j"/>
+  								</index>
+  								<char> </char>
+  							</call>
+  							<int>1</int>
+  						</add>
+  					</var>
+  					<var id="e" store="auto">
+  						<ptr>
+  							<char/>
+  						</ptr>
+  						<call>
+  							<get ref="strchr"/>
+  							<get ref="b"/>
+  							<char> </char>
+  						</call>
+  					</var>
+  					<var id="dst" store="auto">
+  						<ptr>
+  							<char/>
+  						</ptr>
+  						<call>
+  							<get ref="malloc"/>
+  							<get ref="size"/>
+  						</call>
+  					</var>
+  					<call>
+  						<get ref="memmove"/>
+  						<get ref="dst"/>
+  						<get ref="b"/>
+  						<get ref="size"/>
+  					</call>
+  					<set>
+  						<index>
+  							<get ref="dst"/>
+  							<sub>
+  								<get ref="size"/>
+  								<int>1</int>
+  							</sub>
+  						</index>
+  						<get ref="NULL"/>
+  					</set>
+  					<set>
+  						<index>
+  							<get ref="strings"/>
+  							<get ref="i"/>
+  						</index>
+  						<get ref="dst"/>
+  					</set>
+  				</block>
+  			</for>
+  			<set>
+  				<index>
+  					<get ref="strings"/>
+  					<sub>
+  						<get ref="size"/>
+  						<int>1</int>
+  					</sub>
+  				</index>
+  				<get ref="NULL"/>
+  			</set>
+  			<call>
+  				<get ref="print_strings"/>
+  				<get ref="strings"/>
+  			</call>
+  			<for>
+  				<set>
+  					<get ref="i"/>
+  					<int>0</int>
+  				</set>
+  				<lt>
+  					<get ref="i"/>
+  					<get ref="size"/>
+  				</lt>
+  				<postinc>
+  					<get ref="i"/>
+  				</postinc>
+  				<block>
+  					<call>
+  						<get ref="free"/>
+  						<index>
+  							<get ref="strings"/>
+  							<get ref="i"/>
+  						</index>
+  					</call>
+  				</block>
+  			</for>
+  			<return>
+  				<int>0</int>
+  			</return>
+  		</body>
+  	</fundef>
+  </file>
+  $ ctoxml so.c
+  <?xml version="1.0" encoding="iso-8859-1" standalone="yes"?>
+  <file>
+  	<fundec id="foo" store="static">
+  		<type>
+  			<void/>
+  		</type>
+  		<param name="a" store="auto">
+  			<long/>
+  		</param>
+  	</fundec>
+  	<fundec id="bar" store="extern">
+  		<type>
+  			<void/>
+  		</type>
+  		<param name="a" store="auto">
+  			<long/>
+  		</param>
+  	</fundec>
+  </file>
+  $ ctoxml obj.c
+  <?xml version="1.0" encoding="iso-8859-1" standalone="yes"?>
+  <file>
+  	<fundef id="sum_internal_1" store="auto">
+  		<type>
+  			<long/>
+  		</type>
+  		<param name="a" store="auto">
+  			<long/>
+  		</param>
+  		<param name="b" store="auto">
+  			<long/>
+  		</param>
+  		<body>
+  			<return>
+  				<add>
+  					<get ref="a"/>
+  					<get ref="b"/>
+  				</add>
+  			</return>
+  		</body>
+  	</fundef>
+  	<fundec id="sum_internal_3" store="auto">
+  		<type>
+  			<long/>
+  		</type>
+  		<param name="a" store="auto">
+  			<long/>
+  		</param>
+  		<param name="b" store="auto">
+  			<long/>
+  		</param>
+  	</fundec>
+  	<fundef id="sum_internal_2" store="auto">
+  		<type>
+  			<long/>
+  		</type>
+  		<param name="a" store="auto">
+  			<long/>
+  		</param>
+  		<param name="b" store="auto">
+  			<long/>
+  		</param>
+  		<body>
+  			<var id="c" store="auto">
+  				<long/>
+  				<call>
+  					<get ref="sum_internal_3"/>
+  					<get ref="a"/>
+  					<int>42</int>
+  				</call>
+  			</var>
+  			<return>
+  				<add>
+  					<call>
+  						<get ref="sum_internal_1"/>
+  						<get ref="a"/>
+  						<get ref="b"/>
+  					</call>
+  					<get ref="c"/>
+  				</add>
+  			</return>
+  		</body>
+  	</fundef>
+  	<fundec id="sum_external" store="extern">
+  		<type>
+  			<long/>
+  		</type>
+  		<param name="a" store="auto">
+  			<long/>
+  		</param>
+  		<param name="b" store="auto">
+  			<long/>
+  		</param>
+  	</fundec>
+  </file>
+  $ ctoxml symexec-crc32.c
+  <?xml version="1.0" encoding="iso-8859-1" standalone="yes"?>
+  <file>
+  	<fundef id="crc32" store="auto">
+  		<type>
+  			<ulong/>
+  		</type>
+  		<param name="message" store="auto">
+  			<ptr>
+  				<uchar/>
+  			</ptr>
+  		</param>
+  		<body>
+  			<var id="i" store="auto">
+  				<long/>
+  			</var>
+  			<var id="j" store="auto">
+  				<long/>
+  			</var>
+  			<var id="byte" store="auto">
+  				<ulong/>
+  			</var>
+  			<var id="crc" store="auto">
+  				<ulong/>
+  			</var>
+  			<var id="mask" store="auto">
+  				<ulong/>
+  			</var>
+  			<set>
+  				<get ref="i"/>
+  				<int>0</int>
+  			</set>
+  			<set>
+  				<get ref="crc"/>
+  				<int>0xFFFFFFFF</int>
+  			</set>
+  			<while>
+  				<ne>
+  					<index>
+  						<get ref="message"/>
+  						<get ref="i"/>
+  					</index>
+  					<int>0</int>
+  				</ne>
+  				<block>
+  					<set>
+  						<get ref="byte"/>
+  						<index>
+  							<get ref="message"/>
+  							<get ref="i"/>
+  						</index>
+  					</set>
+  					<set>
+  						<get ref="crc"/>
+  						<xor>
+  							<get ref="crc"/>
+  							<get ref="byte"/>
+  						</xor>
+  					</set>
+  					<for>
+  						<set>
+  							<get ref="j"/>
+  							<int>7</int>
+  						</set>
+  						<ge>
+  							<get ref="j"/>
+  							<int>0</int>
+  						</ge>
+  						<postdec>
+  							<get ref="j"/>
+  						</postdec>
+  						<block>
+  							<set>
+  								<get ref="mask"/>
+  								<neg>
+  									<band>
+  										<get ref="crc"/>
+  										<int>1</int>
+  									</band>
+  								</neg>
+  							</set>
+  							<set>
+  								<get ref="crc"/>
+  								<xor>
+  									<shr>
+  										<get ref="crc"/>
+  										<int>1</int>
+  									</shr>
+  									<band>
+  										<int>0xEDB88320</int>
+  										<get ref="mask"/>
+  									</band>
+  								</xor>
+  							</set>
+  						</block>
+  					</for>
+  					<set>
+  						<get ref="i"/>
+  						<add>
+  							<get ref="i"/>
+  							<int>1</int>
+  						</add>
+  					</set>
+  				</block>
+  			</while>
+  			<return>
+  				<bnot>
+  					<get ref="crc"/>
+  				</bnot>
+  			</return>
+  		</body>
+  	</fundef>
+  	<fundef id="main" store="auto">
+  		<type>
+  			<long/>
+  		</type>
+  		<body>
+  			<var id="buf1" store="auto">
+  				<array>
+  					<char/>
+  					<size>
+  						<int>16</int>
+  					</size>
+  				</array>
+  			</var>
+  			<var id="buf2" store="auto">
+  				<array>
+  					<char/>
+  					<size>
+  						<int>16</int>
+  					</size>
+  				</array>
+  			</var>
+  			<if>
+  				<and>
+  					<call>
+  						<get ref="fgets"/>
+  						<get ref="buf1"/>
+  						<sizeof>
+  							<get ref="buf1"/>
+  						</sizeof>
+  						<get ref="stdin"/>
+  					</call>
+  					<call>
+  						<get ref="fgets"/>
+  						<get ref="buf2"/>
+  						<sizeof>
+  							<get ref="buf2"/>
+  						</sizeof>
+  						<get ref="stdin"/>
+  					</call>
+  				</and>
+  				<block>
+  					<if>
+  						<eq>
+  							<call>
+  								<get ref="crc32"/>
+  								<get ref="buf1"/>
+  							</call>
+  							<call>
+  								<get ref="crc32"/>
+  								<get ref="buf2"/>
+  							</call>
+  						</eq>
+  						<block>
+  							<call>
+  								<get ref="puts"/>
+  								<string>access granted</string>
+  							</call>
+  						</block>
+  						<nop/>
+  					</if>
+  				</block>
+  				<nop/>
+  			</if>
+  		</body>
+  	</fundef>
+  </file>
+  $ ctoxml symexec-faux.c
+  <?xml version="1.0" encoding="iso-8859-1" standalone="yes"?>
+  <file>
+  	<var id="sneaky" store="auto">
+  		<ptr>
+  			<char/>
+  		</ptr>
+  		<string>SOSNEAKY</string>
+  	</var>
+  	<fundef id="accepted" store="auto">
+  		<type>
+  			<long/>
+  		</type>
+  		<body>
+  			<call>
+  				<get ref="puts"/>
+  				<string>access granted!</string>
+  			</call>
+  			<call>
+  				<get ref="exit"/>
+  				<int>0</int>
+  			</call>
+  		</body>
+  	</fundef>
+  	<fundef id="rejected" store="auto">
+  		<type>
+  			<long/>
+  		</type>
+  		<body>
+  			<call>
+  				<get ref="exit"/>
+  				<int>1</int>
+  			</call>
+  		</body>
+  	</fundef>
+  	<fundef id="authenticate" store="auto">
+  		<type>
+  			<long/>
+  		</type>
+  		<param name="username" store="auto">
+  			<ptr>
+  				<char/>
+  			</ptr>
+  		</param>
+  		<param name="password" store="auto">
+  			<ptr>
+  				<char/>
+  			</ptr>
+  		</param>
+  		<body>
+  			<var id="entry" store="auto">
+  				<array>
+  					<char/>
+  					<size>
+  						<add>
+  							<mul>
+  								<get ref="BUFSIZE"/>
+  								<int>2</int>
+  							</mul>
+  							<int>2</int>
+  						</add>
+  					</size>
+  				</array>
+  			</var>
+  			<mul>
+  				<get ref="FILE"/>
+  				<get ref="pwfile"/>
+  			</mul>
+  			<if>
+  				<eq>
+  					<call>
+  						<get ref="strcmp"/>
+  						<get ref="password"/>
+  						<get ref="sneaky"/>
+  					</call>
+  					<int>0</int>
+  				</eq>
+  				<return>
+  					<int>1</int>
+  				</return>
+  				<nop/>
+  			</if>
+  			<set>
+  				<get ref="pwfile"/>
+  				<call>
+  					<get ref="fopen"/>
+  					<string>passwd</string>
+  					<string>r</string>
+  				</call>
+  			</set>
+  			<if>
+  				<not>
+  					<get ref="pwfile"/>
+  				</not>
+  				<call>
+  					<get ref="rejected"/>
+  				</call>
+  				<nop/>
+  			</if>
+  			<while>
+  				<call>
+  					<get ref="fgets"/>
+  					<get ref="entry"/>
+  					<sizeof>
+  						<get ref="entry"/>
+  					</sizeof>
+  					<get ref="pwfile"/>
+  				</call>
+  				<block>
+  					<var id="secret" store="auto">
+  						<ptr>
+  							<char/>
+  						</ptr>
+  						<get ref="NULL"/>
+  					</var>
+  					<set>
+  						<get ref="secret"/>
+  						<call>
+  							<get ref="strpbrk"/>
+  							<get ref="entry"/>
+  							<string>:</string>
+  						</call>
+  					</set>
+  					<if>
+  						<get ref="secret"/>
+  						<block>
+  							<set>
+  								<memof>
+  									<postinc>
+  										<get ref="secret"/>
+  									</postinc>
+  								</memof>
+  								<char> </char>
+  							</set>
+  							<set>
+  								<index>
+  									<get ref="secret"/>
+  									<sub>
+  										<call>
+  											<get ref="strlen"/>
+  											<get ref="secret"/>
+  										</call>
+  										<int>1</int>
+  									</sub>
+  								</index>
+  								<char> </char>
+  							</set>
+  							<if>
+  								<and>
+  									<eq>
+  										<call>
+  											<get ref="strcmp"/>
+  											<get ref="entry"/>
+  											<get ref="username"/>
+  										</call>
+  										<int>0</int>
+  									</eq>
+  									<eq>
+  										<call>
+  											<get ref="strcmp"/>
+  											<get ref="secret"/>
+  											<get ref="password"/>
+  										</call>
+  										<int>0</int>
+  									</eq>
+  								</and>
+  								<block>
+  									<return>
+  										<int>1</int>
+  									</return>
+  								</block>
+  								<nop/>
+  							</if>
+  						</block>
+  						<nop/>
+  					</if>
+  				</block>
+  			</while>
+  			<return>
+  				<int>0</int>
+  			</return>
+  		</body>
+  	</fundef>
+  	<fundef id="strip" store="auto">
+  		<type>
+  			<void/>
+  		</type>
+  		<param name="s" store="auto">
+  			<ptr>
+  				<char/>
+  			</ptr>
+  		</param>
+  		<body>
+  			<var id="n" store="auto">
+  				<long/>
+  				<call>
+  					<get ref="strlen"/>
+  					<get ref="s"/>
+  				</call>
+  			</var>
+  			<set>
+  				<index>
+  					<get ref="s"/>
+  					<get ref="n"/>
+  				</index>
+  				<quest>
+  					<eq>
+  						<index>
+  							<get ref="s"/>
+  							<get ref="n"/>
+  						</index>
+  						<char>
+  </char>
+  					</eq>
+  					<char> </char>
+  					<index>
+  						<get ref="s"/>
+  						<get ref="n"/>
+  					</index>
+  				</quest>
+  			</set>
+  		</body>
+  	</fundef>
+  	<fundef id="main" store="auto">
+  		<type>
+  			<long/>
+  		</type>
+  		<param name="argc" store="auto">
+  			<long/>
+  		</param>
+  		<param name="argv" store="auto">
+  			<ptr>
+  				<ptr>
+  					<char/>
+  				</ptr>
+  			</ptr>
+  		</param>
+  		<body>
+  			<var id="username" store="auto">
+  				<array>
+  					<char/>
+  					<size>
+  						<get ref="BUFSIZE"/>
+  					</size>
+  				</array>
+  			</var>
+  			<var id="password" store="auto">
+  				<array>
+  					<char/>
+  					<size>
+  						<get ref="BUFSIZE"/>
+  					</size>
+  				</array>
+  			</var>
+  			<if>
+  				<not>
+  					<call>
+  						<get ref="fgets"/>
+  						<get ref="username"/>
+  						<sizeof>
+  							<get ref="username"/>
+  						</sizeof>
+  						<get ref="stdin"/>
+  					</call>
+  				</not>
+  				<call>
+  					<get ref="rejected"/>
+  				</call>
+  				<nop/>
+  			</if>
+  			<if>
+  				<not>
+  					<call>
+  						<get ref="fgets"/>
+  						<get ref="password"/>
+  						<sizeof>
+  							<get ref="password"/>
+  						</sizeof>
+  						<get ref="stdin"/>
+  					</call>
+  				</not>
+  				<call>
+  					<get ref="rejected"/>
+  				</call>
+  				<nop/>
+  			</if>
+  			<call>
+  				<get ref="strip"/>
+  				<get ref="username"/>
+  			</call>
+  			<call>
+  				<get ref="strip"/>
+  				<get ref="password"/>
+  			</call>
+  			<if>
+  				<call>
+  					<get ref="authenticate"/>
+  					<get ref="username"/>
+  					<get ref="password"/>
+  				</call>
+  				<call>
+  					<get ref="accepted"/>
+  				</call>
+  				<call>
+  					<get ref="rejected"/>
+  				</call>
+  			</if>
+  		</body>
+  	</fundef>
+  </file>
+  $ ctoxml symexec-guess.c
+  <?xml version="1.0" encoding="iso-8859-1" standalone="yes"?>
+  <file>
+  	<fundef id="main" store="auto">
+  		<type>
+  			<long/>
+  		</type>
+  		<body>
+  			<if>
+  				<eq>
+  					<call>
+  						<get ref="getchar"/>
+  					</call>
+  					<char>A</char>
+  				</eq>
+  				<block>
+  					<call>
+  						<get ref="puts"/>
+  						<string>access granted</string>
+  					</call>
+  				</block>
+  				<nop/>
+  			</if>
+  		</body>
+  	</fundef>
+  </file>
+  $ ctoxml symexec-guess-many-tries.c
+  <?xml version="1.0" encoding="iso-8859-1" standalone="yes"?>
+  <file>
+  	<fundef id="main" store="auto">
+  		<type>
+  			<long/>
+  		</type>
+  		<body>
+  			<while>
+  				<int>1</int>
+  				<block>
+  					<var id="c" store="auto">
+  						<long/>
+  						<call>
+  							<get ref="getchar"/>
+  						</call>
+  					</var>
+  					<if>
+  						<eq>
+  							<get ref="c"/>
+  							<char>A</char>
+  						</eq>
+  						<block>
+  							<call>
+  								<get ref="puts"/>
+  								<string>access granted</string>
+  							</call>
+  							<return>
+  								<int>0</int>
+  							</return>
+  						</block>
+  						<nop/>
+  					</if>
+  					<if>
+  						<le>
+  							<get ref="c"/>
+  							<int>0</int>
+  						</le>
+  						<block>
+  							<return>
+  								<int>1</int>
+  							</return>
+  						</block>
+  						<nop/>
+  					</if>
+  					<if>
+  						<eq>
+  							<get ref="c"/>
+  							<char>
+  </char>
+  						</eq>
+  						<block>
+  							<continue/>
+  						</block>
+  						<nop/>
+  					</if>
+  				</block>
+  			</while>
+  		</body>
+  	</fundef>
+  </file>
+  $ ctoxml symexec-guess-many-tries-switch.c
+  <?xml version="1.0" encoding="iso-8859-1" standalone="yes"?>
+  <file>
+  	<fundef id="main" store="auto">
+  		<type>
+  			<long/>
+  		</type>
+  		<body>
+  			<while>
+  				<int>1</int>
+  				<block>
+  					<switch>
+  						<call>
+  							<get ref="getchar"/>
+  						</call>
+  						<block>
+  							<case>
+  								<bor>
+  									<neg>
+  										<int>1</int>
+  									</neg>
+  									<int>0</int>
+  								</bor>
+  								<call>
+  									<get ref="puts"/>
+  									<string>good bye!</string>
+  								</call>
+  							</case>
+  							<return>
+  								<int>1</int>
+  							</return>
+  							<case>
+  								<char>A</char>
+  								<call>
+  									<get ref="puts"/>
+  									<string>access granted</string>
+  								</call>
+  							</case>
+  							<return>
+  								<int>0</int>
+  							</return>
+  							<case>
+  								<char>
+  </char>
+  								<continue/>
+  							</case>
+  						</block>
+  					</switch>
+  				</block>
+  			</while>
+  		</body>
+  	</fundef>
+  </file>
+  $ ctoxml symexec-input.c
+  <?xml version="1.0" encoding="iso-8859-1" standalone="yes"?>
+  <file>
+  	<fundef id="main" store="auto">
+  		<type>
+  			<long/>
+  		</type>
+  		<body>
+  			<var id="buf" store="auto">
+  				<array>
+  					<char/>
+  					<size>
+  						<int>16</int>
+  					</size>
+  				</array>
+  			</var>
+  			<mul>
+  				<get ref="FILE"/>
+  				<get ref="input"/>
+  			</mul>
+  			<and>
+  				<and>
+  					<and>
+  						<set>
+  							<get ref="input"/>
+  							<call>
+  								<get ref="fopen"/>
+  								<string>passwd</string>
+  								<string>r</string>
+  							</call>
+  						</set>
+  						<call>
+  							<get ref="fgets"/>
+  							<get ref="buf"/>
+  							<sizeof>
+  								<get ref="buf"/>
+  							</sizeof>
+  							<get ref="input"/>
+  						</call>
+  					</and>
+  					<eq>
+  						<call>
+  							<get ref="strncmp"/>
+  							<get ref="buf"/>
+  							<string>backdoor</string>
+  							<int>8</int>
+  						</call>
+  						<int>0</int>
+  					</eq>
+  				</and>
+  				<call>
+  					<get ref="puts"/>
+  					<string>access granted</string>
+  				</call>
+  			</and>
+  		</body>
+  	</fundef>
+  </file>
+  $ ctoxml symexec-palindrome.c
+  <?xml version="1.0" encoding="iso-8859-1" standalone="yes"?>
+  <file>
+  	<fundef id="main" store="auto">
+  		<type>
+  			<long/>
+  		</type>
+  		<body>
+  			<var id="buf" store="auto">
+  				<array>
+  					<char/>
+  					<size>
+  						<int>8</int>
+  					</size>
+  				</array>
+  			</var>
+  			<if>
+  				<call>
+  					<get ref="fgets"/>
+  					<get ref="buf"/>
+  					<sizeof>
+  						<get ref="buf"/>
+  					</sizeof>
+  					<get ref="stdin"/>
+  				</call>
+  				<block>
+  					<var id="i" store="auto">
+  						<long/>
+  					</var>
+  					<var id="n" store="auto">
+  						<long/>
+  						<sub>
+  							<call>
+  								<get ref="strlen"/>
+  								<get ref="buf"/>
+  							</call>
+  							<int>1</int>
+  						</sub>
+  					</var>
+  					<for>
+  						<set>
+  							<get ref="i"/>
+  							<int>0</int>
+  						</set>
+  						<and>
+  							<and>
+  								<gt>
+  									<get ref="n"/>
+  									<int>2</int>
+  								</gt>
+  								<le>
+  									<get ref="i"/>
+  									<div>
+  										<get ref="n"/>
+  										<int>2</int>
+  									</div>
+  								</le>
+  							</and>
+  							<eq>
+  								<index>
+  									<get ref="buf"/>
+  									<get ref="i"/>
+  								</index>
+  								<index>
+  									<get ref="buf"/>
+  									<sub>
+  										<sub>
+  											<get ref="n"/>
+  											<get ref="i"/>
+  										</sub>
+  										<int>1</int>
+  									</sub>
+  								</index>
+  							</eq>
+  						</and>
+  						<postinc>
+  							<get ref="i"/>
+  						</postinc>
+  						<nop/>
+  					</for>
+  					<if>
+  						<gt>
+  							<get ref="i"/>
+  							<div>
+  								<get ref="n"/>
+  								<int>2</int>
+  							</div>
+  						</gt>
+  						<block>
+  							<call>
+  								<get ref="puts"/>
+  								<string>access granted!</string>
+  							</call>
+  						</block>
+  						<nop/>
+  					</if>
+  				</block>
+  				<nop/>
+  			</if>
+  		</body>
+  	</fundef>
+  </file>
+  $ ctoxml symexec-simple.c
+  <?xml version="1.0" encoding="iso-8859-1" standalone="yes"?>
+  <file>
+  	<fundef id="main" store="auto">
+  		<type>
+  			<long/>
+  		</type>
+  		<body>
+  			<var id="buf" store="auto">
+  				<array>
+  					<char/>
+  					<size>
+  						<int>16</int>
+  					</size>
+  				</array>
+  			</var>
+  			<var id="bytes_read" store="auto">
+  				<long/>
+  				<call>
+  					<get ref="read"/>
+  					<int>0</int>
+  					<get ref="buf"/>
+  					<sub>
+  						<sizeof>
+  							<get ref="buf"/>
+  						</sizeof>
+  						<int>1</int>
+  					</sub>
+  				</call>
+  			</var>
+  			<if>
+  				<ne>
+  					<get ref="bytes_read"/>
+  					<neg>
+  						<int>1</int>
+  					</neg>
+  				</ne>
+  				<block>
+  					<set>
+  						<index>
+  							<get ref="buf"/>
+  							<get ref="bytes_read"/>
+  						</index>
+  						<int>0</int>
+  					</set>
+  					<if>
+  						<eq>
+  							<call>
+  								<get ref="strcmp"/>
+  								<get ref="buf"/>
+  								<string>backdoor</string>
+  							</call>
+  							<int>0</int>
+  						</eq>
+  						<block>
+  							<call>
+  								<get ref="puts"/>
+  								<string>access granted!</string>
+  							</call>
+  						</block>
+  						<nop/>
+  					</if>
+  				</block>
+  				<nop/>
+  			</if>
+  		</body>
+  	</fundef>
+  </file>
+  $ ctoxml trivial.c
+  <?xml version="1.0" encoding="iso-8859-1" standalone="yes"?>
+  <file>
+  	<fundef id="main" store="auto">
+  		<type>
+  			<long/>
+  		</type>
+  		<param name="argc" store="auto">
+  			<long/>
+  		</param>
+  		<param name="argv" store="auto">
+  			<array>
+  				<ptr>
+  					<const>
+  						<char/>
+  					</const>
+  				</ptr>
+  				<size>
+  					<nothing/>
+  				</size>
+  			</array>
+  		</param>
+  		<body>
+  			<var id="i" store="auto">
+  				<long/>
+  			</var>
+  			<for>
+  				<set>
+  					<get ref="i"/>
+  					<int>0</int>
+  				</set>
+  				<lt>
+  					<get ref="i"/>
+  					<get ref="argc"/>
+  				</lt>
+  				<postinc>
+  					<get ref="i"/>
+  				</postinc>
+  				<block>
+  					<call>
+  						<get ref="puts"/>
+  						<index>
+  							<get ref="argv"/>
+  							<get ref="i"/>
+  						</index>
+  					</call>
+  				</block>
+  			</for>
+  			<call>
+  				<get ref="abort"/>
+  			</call>
+  		</body>
+  	</fundef>
+  </file>
+
+  $ ctoxml anonymous-structs.c
+  <?xml version="1.0" encoding="iso-8859-1" standalone="yes"?>
+  <file>
+  	<struct id="struct:Scope">
+  		<field name="">
+  			<union>
+  				<field name="num">
+  					<long/>
+  				</field>
+  				<field name="alpha">
+  					<char/>
+  				</field>
+  			</union>
+  		</field>
+  	</struct>
+  	<struct id="struct:Scope2">
+  		<field name="">
+  			<struct>
+  				<field name="num">
+  					<long/>
+  				</field>
+  				<field name="alpha">
+  					<char/>
+  				</field>
+  			</struct>
+  		</field>
+  	</struct>
+  </file>
+
+  $ ctoxml atomic_parenthesis.c
+  <?xml version="1.0" encoding="iso-8859-1" standalone="yes"?>
+  <file>
+  	<var id="_Atomic" store="auto">
+  		<fun>
+  			<vararg/>
+  		</fun>
+  	</var>
+  </file>
+  $ ctoxml dangling_else.c
+  <?xml version="1.0" encoding="iso-8859-1" standalone="yes"?>
+  <file>
+  	<fundef id="f" store="auto">
+  		<type>
+  			<long/>
+  		</type>
+  		<body>
+  			<if>
+  				<int>0</int>
+  				<if>
+  					<int>1</int>
+  					<return>
+  						<int>1</int>
+  					</return>
+  					<return>
+  						<int>0</int>
+  					</return>
+  				</if>
+  				<nop/>
+  			</if>
+  			<return>
+  				<int>1</int>
+  			</return>
+  		</body>
+  	</fundef>
+  </file>
+  $ ctoxml enum.c
+  <?xml version="1.0" encoding="iso-8859-1" standalone="yes"?>
+  <file>
+  	<type id="foo" store="auto">
+  		<enum>
+  			<value name="a">
+  				<nothing/>
+  			</value>
+  			<value name="b">
+  				<get ref="a"/>
+  			</value>
+  		</enum>
+  	</type>
+  </file>
+  $ ctoxml struct-recursion.c
+  <?xml version="1.0" encoding="iso-8859-1" standalone="yes"?>
+  <file>
+  	<struct id="struct:s1">
+  		<field name="A">
+  			<ptr>
+  				<struct ref="struct:s2"/>
+  			</ptr>
+  		</field>
+  	</struct>
+  	<struct id="struct:s2">
+  		<field name="B">
+  			<ptr>
+  				<struct ref="struct:s1"/>
+  			</ptr>
+  		</field>
+  	</struct>
+  	<var id="a" store="auto">
+  		<struct ref="struct:s1"/>
+  	</var>
+  	<var id="b" store="auto">
+  		<struct ref="struct:s2"/>
+  	</var>
+  </file>

--- a/ctoxml/test.t/so.c
+++ b/ctoxml/test.t/so.c
@@ -1,0 +1,11 @@
+
+static void foo(int a);
+extern void bar(int a);
+
+static void foo(int a) {
+    bar(a);
+}
+
+extern void bar(int a) {
+    foo(a);
+}

--- a/ctoxml/test.t/struct-recursion.c
+++ b/ctoxml/test.t/struct-recursion.c
@@ -1,0 +1,11 @@
+// RUN: %clang_cc1 %s -fsyntax-only
+
+// C99 6.7.2.3p11
+
+// mutually recursive structs
+struct s1 { struct s2 *A; };
+struct s2 { struct s1 *B; };
+
+// both types are complete now.
+struct s1 a;
+struct s2 b;

--- a/ctoxml/test.t/symexec-crc32.c
+++ b/ctoxml/test.t/symexec-crc32.c
@@ -1,0 +1,29 @@
+#include <stdio.h>
+
+unsigned int crc32(unsigned char *message) {
+    int i, j;
+    unsigned int byte, crc, mask;
+
+    i = 0;
+    crc = 0xFFFFFFFF;
+    while (message[i] != 0) {
+        byte = message[i];
+        crc = crc ^ byte;
+        for (j = 7; j >= 0; j--) {
+            mask = -(crc & 1);
+            crc = (crc >> 1) ^ (0xEDB88320 & mask);
+        }
+        i = i + 1;
+    }
+    return ~crc;
+}
+
+int main(void) {
+    char buf1[16];
+    char buf2[16];
+    if (fgets(buf1,sizeof(buf1),stdin) && fgets(buf2,sizeof(buf2),stdin)) {
+        if (crc32(buf1) == crc32(buf2)) {
+            puts("access granted");
+        }
+    }
+}

--- a/ctoxml/test.t/symexec-faux.c
+++ b/ctoxml/test.t/symexec-faux.c
@@ -1,0 +1,66 @@
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <stdlib.h>
+
+char *sneaky = "SOSNEAKY";
+
+#define BUFSIZE 16
+
+int accepted() {
+    puts("access granted!");
+    exit(0);
+}
+
+int rejected() {
+    exit(1);
+}
+
+int authenticate(char *username, char *password) {
+    char entry[BUFSIZE*2+2];
+    FILE *pwfile;
+
+    // evil back d00r
+    if (strcmp(password, sneaky) == 0) return 1;
+
+    pwfile = fopen("passwd", "r");
+    if (!pwfile)
+        rejected();
+
+    while (fgets(entry, sizeof(entry), pwfile)) {
+        char *secret = NULL;
+        secret = strpbrk(entry, ":");
+        if (secret)  {
+            *secret++ = '\0';
+            secret[strlen(secret)-1] = '\0';
+            if (strcmp(entry, username) == 0 &&
+                strcmp(secret, password) == 0) {
+                return 1;
+            }
+        }
+    }
+    return 0;
+}
+
+void strip(char *s) {
+    int n = strlen(s);
+    s[n] = s[n] == '\n' ? '\0' : s[n];
+}
+
+int main(int argc, char **argv)
+{
+    char username[BUFSIZE];
+    char password[BUFSIZE];
+
+    if (!fgets(username, sizeof(username), stdin))
+        rejected();
+    if (!fgets(password, sizeof(password), stdin))
+        rejected();
+
+    strip(username);
+    strip(password);
+
+    if (authenticate(username, password)) accepted();
+    else rejected();
+}

--- a/ctoxml/test.t/symexec-guess-many-tries-switch.c
+++ b/ctoxml/test.t/symexec-guess-many-tries-switch.c
@@ -1,0 +1,16 @@
+#include <stdio.h>
+
+int main(void) {
+    while (1) {
+        switch (getchar()) {
+        case (-1|0):
+            puts("good bye!");
+            return 1;
+        case 'A':
+            puts("access granted");
+            return 0;
+        case '\n':
+            continue;
+        }
+    }
+}

--- a/ctoxml/test.t/symexec-guess-many-tries.c
+++ b/ctoxml/test.t/symexec-guess-many-tries.c
@@ -1,0 +1,18 @@
+#include <stdio.h>
+
+
+int main(void) {
+    while (1) {
+        int c = getchar();
+        if (c == 'A') {
+            puts("access granted");
+            return 0;
+        }
+        if (c <= 0) {
+            return 1;
+        }
+        if (c == '\n') {
+            continue;
+        }
+    }
+}

--- a/ctoxml/test.t/symexec-guess.c
+++ b/ctoxml/test.t/symexec-guess.c
@@ -1,0 +1,8 @@
+#include <stdio.h>
+
+
+int main(void) {
+    if (getchar() == 'A') {
+        puts("access granted");
+    }
+}

--- a/ctoxml/test.t/symexec-input.c
+++ b/ctoxml/test.t/symexec-input.c
@@ -1,0 +1,12 @@
+#include <stdio.h>
+#include <unistd.h>
+#include <string.h>
+
+int main(void) {
+    char buf[16];
+    FILE *input;
+    (input = fopen("passwd", "r"))   &&
+    fgets(buf, sizeof(buf), input)   &&
+    strncmp(buf, "backdoor", 8) == 0 &&
+    puts("access granted");
+}

--- a/ctoxml/test.t/symexec-palindrome.c
+++ b/ctoxml/test.t/symexec-palindrome.c
@@ -1,0 +1,14 @@
+#include <stdio.h>
+#include <string.h>
+
+int main(void) {
+    char buf[8];
+    if (fgets(buf, sizeof(buf), stdin)) {
+        int i;
+        int n = strlen(buf)-1;
+        for (i = 0; n > 2 && i <= n/2 && buf[i] == buf[n-i-1];i++);
+        if (i > n/2) {
+            puts("access granted!");
+        }
+    }
+}

--- a/ctoxml/test.t/symexec-simple.c
+++ b/ctoxml/test.t/symexec-simple.c
@@ -1,0 +1,14 @@
+#include <stdio.h>
+#include <unistd.h>
+#include <string.h>
+
+int main(void) {
+    char buf[16];
+    int bytes_read = read(0, buf, sizeof(buf) - 1);
+    if (bytes_read != -1) {
+        buf[bytes_read] = 0;
+        if (strcmp(buf, "backdoor") == 0) {
+            puts("access granted!");
+        }
+    }
+}

--- a/ctoxml/test.t/trivial.c
+++ b/ctoxml/test.t/trivial.c
@@ -1,0 +1,10 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(int argc, const char *argv[]) {
+    int i;
+    for (i = 0; i < argc; i++) {
+        puts(argv[i]);
+    }
+    abort();
+}


### PR DESCRIPTION
Adds a few files with xml output to track that the structure of the parsed program is not changed.

P.S. Originally, I tried to use `-pp` but it looks like that is not going to work with Windows and macOS targets. The latter was failing on the preprocessor itself the former was throwing some errors that really need investigation, like empty tokens from lexer. I will now try to reproduce them locally. 