### PR TITLE
Support designated initialization style.

### DIFF
--- a/ctoxml/test.t/c99-struct-initializers.c
+++ b/ctoxml/test.t/c99-struct-initializers.c
@@ -1,0 +1,15 @@
+struct point {
+  int    x;
+  int    y;
+};
+
+struct point3d {
+  int    x;
+  int    y;
+  int    z;
+};
+
+int main() {
+  struct point p = { .y = 2, .x = 1 };
+  struct point3d p2 = { .z = 2, .x = 1, 5 }; // mixing both styles
+}

--- a/ctoxml/test.t/run.t
+++ b/ctoxml/test.t/run.t
@@ -5331,3 +5331,57 @@
   		<struct ref="struct:s2"/>
   	</var>
   </file>
+  $ ctoxml c99-struct-initializers.c
+  <?xml version="1.0" encoding="iso-8859-1" standalone="yes"?>
+  <file>
+  	<struct id="struct:point">
+  		<field name="y">
+  			<long/>
+  		</field>
+  		<field name="x">
+  			<long/>
+  		</field>
+  	</struct>
+  	<struct id="struct:point3d">
+  		<field name="z">
+  			<long/>
+  		</field>
+  		<field name="y">
+  			<long/>
+  		</field>
+  		<field name="x">
+  			<long/>
+  		</field>
+  	</struct>
+  	<fundef id="main" store="auto">
+  		<type>
+  			<long/>
+  		</type>
+  		<body>
+  			<var id="p" store="auto">
+  				<struct ref="struct:point"/>
+  				<compound>
+  					<designated name="y">
+  						<int>2</int>
+  					</designated>
+  					<designated name="x">
+  						<int>1</int>
+  					</designated>
+  				</compound>
+  			</var>
+  			<var id="p2" store="auto">
+  				<struct ref="struct:point3d"/>
+  				<compound>
+  					<designated name="z">
+  						<int>2</int>
+  					</designated>
+  					<designated name="x">
+  						<int>1</int>
+  					</designated>
+  					<int>5</int>
+  				</compound>
+  			</var>
+  			<nop/>
+  		</body>
+  	</fundef>
+  </file>

--- a/frontc/cabs.ml
+++ b/frontc/cabs.ml
@@ -229,6 +229,8 @@ and expression =
   (** Pointer indirection through "->". *)
   | GNU_BODY of body
   (** GNU braces inside an expression. *)
+  | DESIGNATED of string * expression
+  (** Designated initialization, in compound constants only. *)
   | EXPR_LINE of expression * string * int
   (** Record the file and line of the expression. *)
 

--- a/frontc/cparser.mly
+++ b/frontc/cparser.mly
@@ -780,7 +780,7 @@ enum_name: IDENT      {($1, NOTHING)}
 
 /*** Expressions ****/
 init_expression:
-LBRACE init_comma_expression RBRACE
+LBRACE compound_comma_expression RBRACE
     {CONSTANT (CONST_COMPOUND (List.rev $2))}
   |  expression
     {$1}
@@ -791,6 +791,22 @@ init_expression
   |  init_comma_expression COMMA init_expression
     {$3::$1}
   |  init_comma_expression COMMA
+    {$1}
+;
+compound_expression:
+LBRACE compound_comma_expression RBRACE
+    {CONSTANT (CONST_COMPOUND (List.rev $2))}
+  |  expression
+    {$1}
+  | DOT type_name EQ expression
+    { DESIGNATED ($2, $4) }
+;
+compound_comma_expression:
+compound_expression
+    {[$1]}
+  |  compound_comma_expression COMMA compound_expression
+    {$3::$1}
+  |  compound_comma_expression COMMA
     {$1}
 ;
 opt_expression:

--- a/frontc/cprint.ml
+++ b/frontc/cprint.ml
@@ -337,7 +337,7 @@ and print_old_params pars ell =
 (*
 ** Expression printing
 **		Priorities
-**		16	varaibles
+**		16	variables
 **		15	. -> [] call()
 **		14  ++, -- (post)
 **		13	++ -- (pre) ~ ! - + & *(cast)
@@ -413,6 +413,7 @@ and get_operator exp =
   | MEMBEROF _ -> ("", 15)
   | MEMBEROFPTR _ -> ("", 15)
   | GNU_BODY _ -> ("", 17)
+  | DESIGNATED _ -> ("", 15)
   | EXPR_LINE (expr, _, _) -> get_operator expr
 
 and print_comma_exps exps =
@@ -487,6 +488,11 @@ and print_expression (exp : expression) (lvl : int) =
       print "(";
       print_statement (BLOCK (decs, stat));
       print ")"
+    | DESIGNATED (member, exp) ->
+      print ".";
+      print member;
+      print "=";
+      print_expression exp 16;
     | EXPR_LINE (expr, _, _) ->
       print_expression expr lvl in
   if lvl > lvl' then print ")" else ()

--- a/frontc/ctoxml.ml
+++ b/frontc/ctoxml.ml
@@ -115,6 +115,8 @@ and convert_exp exp =
     Cxml.new_elt "memberofptr" [("field", n)] [convert_exp b]
   | GNU_BODY (d, s) ->
     Cxml.new_elt "body" [] (convert_block (d, s))
+  | DESIGNATED (n, e) ->
+    Cxml.new_elt "designated" [("name", n)] [convert_exp e]
   | EXPR_LINE (expr, file, line) ->
     Cxml.new_elt "expr_line"
       [("file", file); ("line", string_of_int line)]


### PR DESCRIPTION
Fixes #32.

* frontc/cabs.ml: Add `DESIGNATED` expression type for struct
initialization.
* frontc/cparser.mly: Add rules for compounds (struct initialization).  A
compound contains a list of expressions or designated, but a standard
initialization cannot be a designated outside a compound.
* frontc/cprint.ml: Print new AST type.
* frontc/ctoxml.ml: Print XML for new designated AST type.
* ctoxml/test.t/c99-struct-initializers.c: New test.
* ctoxml/test.t/run.t: Update expected output for new test.