### PR TITLE
relaxes the bitfield declaration

### DIFF
--- a/frontc/cparser.mly
+++ b/frontc/cparser.mly
@@ -79,7 +79,7 @@
         | BITFIELD (NO_SIGN, exp) ->
            (match tst with
               INT (_, sign) -> BITFIELD (sign, exp)
-            | _ -> raise BadType)
+            | _ -> typ)
         | _ -> raise BadType in
       set tin
 


### PR DESCRIPTION
Modern compilers accept bitfields with typedefed types despite that the
standard is not quite clear if this acceptable. FrontC strictly
requires a builtin integer type, e.g., `int`, `unsigned`, or `signed`
as the type of bitfiled. The reason for this is that we need to lookup
for the signedness of the field to construct a proper bitfield and
since we're not storing the original type of a typedefed type anywhere
we can't get this information for a typedefed type. The quick fix is
to keep signedness unspecified for the typedefed types.

Fixes #51