### PR TITLE
Fix overlapping exception name resulting in build failure

### DIFF
--- a/frontc/cparser.mly
+++ b/frontc/cparser.mly
@@ -1,11 +1,11 @@
 %{
     open Cabs
 
-    exception Error
+    exception ParseError
 
     let parse_error startpos endpos =
       Clexer.display_error "Syntax error" startpos endpos;
-      raise Error
+      raise ParseError
 
     (*
      ** Type analysis


### PR DESCRIPTION
Getting this error without this patch:

```sh
❯ dune build
File "frontc/cxml.ml", line 43, characters 19-20:
Error: Syntax error
File "frontc/cparser.mly", line 4, characters 14-19:
Error: Multiple definition of the extension constructor name Error.
       Names must be unique in a given structure or signature.
```