### PR TITLE
Allow comma before brace for named enum

### DIFF
--- a/frontc/cparser.mly
+++ b/frontc/cparser.mly
@@ -774,6 +774,8 @@ enum_type:
     {ENUM ("", List.rev $3)}
   |  ENUM type_name LBRACE enum_list RBRACE
     {ENUM ($2, List.rev $4)}
+  |  ENUM type_name LBRACE enum_list COMMA RBRACE
+    {ENUM ($2, List.rev $4)}
 ;
 type_name:
 IDENT       {$1}


### PR DESCRIPTION
In cparser.mly, an enum is only allowed to have a comma directly before a } if the enum doesn't specify a type name, but if the enum does specify a type name, it throws a Cparser.MenhirBasics.Error. For example, in this file, the first enum declaration succeeds but the second causes an error (comment out the second one and see that the error disappears):
```
enum {
  FOO,
  BAR,
  BAZ,
};

enum Fooble {
  QUUX,
  FRED,
};
```
This change allows the second one to parse successfully.